### PR TITLE
Merge some award classes

### DIFF
--- a/aux_data/canonical.yaml
+++ b/aux_data/canonical.yaml
@@ -1,3 +1,8 @@
+ACTOR IN A LEADING ROLE:
+- ACTOR
+ACTRESS IN A LEADING ROLE:
+- ACTRESS
+
 BEST PICTURE:
 - BEST MOTION PICTURE
 - OUTSTANDING MOTION PICTURE
@@ -15,6 +20,7 @@ SHORT FILM (Animated):
 
 SHORT FILM (Live Action):
 - SHORT SUBJECT (Live Action)
+- SHORT FILM (Dramatic Live Action)
 - Live Action Short Film
 
 MUSIC (Original Score):
@@ -36,6 +42,7 @@ MUSIC (Original Song Score or Adaptation Score):
 - MUSIC (Adaptation Score)
 - MUSIC (Original Musical or Comedy Score)
 - MUSIC (Scoring of Music--adaptation or treatment)
+- MUSIC (Scoring)
 
 MUSIC (Original Song):
  - MUSIC (Song)
@@ -57,13 +64,12 @@ WRITING (Adapted Screenplay):
  - WRITING (Screenplay Based on Material from Another Medium)
  - WRITING (Screenplay Based on Material Previously Produced or Published)
  - WRITING (Adaptation)
+ - WRITING (Screenplay)
+ - WRITING
 
 WRITING (Original Story):
  - WRITING (Motion Picture Story)
  - WRITING (Original Motion Picture Story)
-
-WRITING (Screenplay):
- - WRITING
 
 DOCUMENTARY (Feature):
  - DOCUMENTARY
@@ -78,6 +84,12 @@ MAKEUP AND HAIRSTYLING:
 SOUND EDITING:
  - SOUND EFFECTS EDITING
  - SOUND EFFECTS
+
+SOUND MIXING:
+- SOUND
+
+ART DIRECTION:
+- PRODUCTION DESIGN
 
 VISUAL EFFECTS:
  - SPECIAL VISUAL EFFECTS

--- a/aux_data/classes.yaml
+++ b/aux_data/classes.yaml
@@ -1,8 +1,6 @@
 Acting:
- - ACTOR
  - ACTOR IN A LEADING ROLE
  - ACTOR IN A SUPPORTING ROLE
- - ACTRESS
  - ACTRESS IN A LEADING ROLE
  - ACTRESS IN A SUPPORTING ROLE
 
@@ -14,7 +12,6 @@ Directing:
 
 Writing:
  - WRITING (Original Screenplay)
- - WRITING (Screenplay)
  - WRITING (Adapted Screenplay)
  - WRITING (Original Story)
  - WRITING (Title Writing)
@@ -28,7 +25,6 @@ Title:
  - DOCUMENTARY (Feature)
  - SHORT FILM (Live Action)
  - SHORT FILM (Animated)
- - SHORT FILM (Dramatic Live Action)
  - SHORT SUBJECT (One-reel)
  - SHORT SUBJECT (Two-reel)
  - SHORT SUBJECT (Comedy)
@@ -54,8 +50,6 @@ Production:
  - CINEMATOGRAPHY
  - CINEMATOGRAPHY (Black-and-White)
  - CINEMATOGRAPHY (Color)
- - PRODUCTION DESIGN
- - SOUND
  - SOUND RECORDING
  - SOUND EDITING
  - SOUND MIXING

--- a/oscars.csv
+++ b/oscars.csv
@@ -1,13 +1,13 @@
 Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	NomineeIds	Winner	Detail	Note	Citation	MultifilmNomination
-1	1927/28	Acting	ACTOR	ACTOR	an0051251	The Noose	tt0019217	Richard Barthelmess	Richard Barthelmess	nm0001932		Nickie Elkins			True
-1	1927/28	Acting	ACTOR	ACTOR	an0051252	The Patent Leather Kid	tt0018253	Richard Barthelmess	Richard Barthelmess	nm0001932		The Patent Leather Kid			True
-1	1927/28	Acting	ACTOR	ACTOR	an0051250a	The Last Command	tt0019071	Emil Jannings	Emil Jannings	nm0417837	True	General Dolgorucki [Grand Duke Sergius Alexander]			True
-1	1927/28	Acting	ACTOR	ACTOR	an0051250b	The Way of All Flesh	tt0019553	Emil Jannings	Emil Jannings	nm0417837	True	August Schilling			True
-1	1927/28	Acting	ACTRESS	ACTRESS	an0051255	A Ship Comes In	tt0018389	Louise Dresser	Louise Dresser	nm0237571		Mrs. Pleznik
-1	1927/28	Acting	ACTRESS	ACTRESS	an0051254a	7th Heaven	tt0018379	Janet Gaynor	Janet Gaynor	nm0310980	True	Diane			True
-1	1927/28	Acting	ACTRESS	ACTRESS	an0051254b	Street Angel	tt0019429	Janet Gaynor	Janet Gaynor	nm0310980	True	Angela			True
-1	1927/28	Acting	ACTRESS	ACTRESS	an0051254c	Sunrise	tt0018455	Janet Gaynor	Janet Gaynor	nm0310980	True	The Wife			True
-1	1927/28	Acting	ACTRESS	ACTRESS	an0051256	Sadie Thompson	tt0019344	Gloria Swanson	Gloria Swanson	nm0841797		Sadie Thompson
+1	1927/28	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051251	The Noose	tt0019217	Richard Barthelmess	Richard Barthelmess	nm0001932		Nickie Elkins			True
+1	1927/28	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051252	The Patent Leather Kid	tt0018253	Richard Barthelmess	Richard Barthelmess	nm0001932		The Patent Leather Kid			True
+1	1927/28	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051250a	The Last Command	tt0019071	Emil Jannings	Emil Jannings	nm0417837	True	General Dolgorucki [Grand Duke Sergius Alexander]			True
+1	1927/28	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051250b	The Way of All Flesh	tt0019553	Emil Jannings	Emil Jannings	nm0417837	True	August Schilling			True
+1	1927/28	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051255	A Ship Comes In	tt0018389	Louise Dresser	Louise Dresser	nm0237571		Mrs. Pleznik
+1	1927/28	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051254a	7th Heaven	tt0018379	Janet Gaynor	Janet Gaynor	nm0310980	True	Diane			True
+1	1927/28	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051254b	Street Angel	tt0019429	Janet Gaynor	Janet Gaynor	nm0310980	True	Angela			True
+1	1927/28	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051254c	Sunrise	tt0018455	Janet Gaynor	Janet Gaynor	nm0310980	True	The Wife			True
+1	1927/28	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051256	Sadie Thompson	tt0019344	Gloria Swanson	Gloria Swanson	nm0841797		Sadie Thompson
 1	1927/28	Production	ART DIRECTION	ART DIRECTION	an0051282	Sunrise	tt0018455	Rochus Gliese	Rochus Gliese	nm0322843
 1	1927/28	Production	ART DIRECTION	ART DIRECTION	an0051279	The Dove	tt0017822	William Cameron Menzies	William Cameron Menzies	nm0580017	True				True
 1	1927/28	Production	ART DIRECTION	ART DIRECTION	an0051280	Tempest	tt0019451	William Cameron Menzies	William Cameron Menzies	nm0580017	True				True
@@ -40,17 +40,17 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 1	1927/28	Writing	WRITING (Title Writing)	WRITING (Title Writing)	an0051270			George Marion, Jr.	George Marion Jr.	nm0547938			NOTE: This nomination was not associated with any specific film title.
 1	1927/28	Special	SPECIAL AWARD	SPECIAL AWARD	an0051420	The Jazz Singer	tt0018037		Warner Bros.	co0080422	True			To Warner Bros., for producing The Jazz Singer, the pioneer outstanding talking picture, which has revolutionized the industry.
 1	1927/28	Special	SPECIAL AWARD	SPECIAL AWARD	an0051421	The Circus	tt0018773		Charles Chaplin	nm0000122	True		NOTE: \"The Academy Board of Judges on merit awards for individual achievements in motion picture arts during the year ending August 1, 1928, unanimously decided that your name should be removed from the competitive classes, and that a special first award be conferred upon you for writing, acting, directing and producing The Circus. The collective accomplishments thus displayed place you in a class by yourself.\" (Letter from the Academy to Mr. Chaplin, dated February 19, 1929.)	To Charles Chaplin, for acting, writing, directing and producing The Circus.
-2	1928/29	Acting	ACTOR	ACTOR	an0053792	Thunderbolt	tt0020499	George Bancroft	George Bancroft	nm0051628		Thunderbolt Jim Lang	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTOR	ACTOR	an0053791	In Old Arizona	tt0020018	Warner Baxter	Warner Baxter	nm0062828	True	The Cisco Kid	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930.
-2	1928/29	Acting	ACTOR	ACTOR	an0053793	Alibi	tt0019630	Chester Morris	Chester Morris	nm0606431		No. 1065, Chick Williams	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTOR	ACTOR	an0053794	The Valiant	tt0020543	Paul Muni	Paul Muni	nm0612847		James Dyke	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTOR	ACTOR	an0053795	The Patriot	tt0019257	Lewis Stone	Lewis Stone	nm0832011		Count Pahlen	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTRESS	ACTRESS	an0053797	Madame X	tt0020126	Ruth Chatterton	Ruth Chatterton	nm0154183		Jacqueline Floriot	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTRESS	ACTRESS	an0053798	The Barker	tt0018674	Betty Compson	Betty Compson	nm0173993		Carrie	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTRESS	ACTRESS	an0053799	The Letter	tt0020092	Jeanne Eagels	Jeanne Eagels	nm0247074		Leslie Crosbie	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTRESS	ACTRESS	an0053800	The Divine Lady	tt0019824	Corinne Griffith	Corinne Griffith	nm0341464		Emma Hart, Lady Hamilton	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTRESS	ACTRESS	an0053801	The Broadway Melody	tt0019729	Bessie Love	Bessie Love	nm0522281		Hank Mahoney	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Acting	ACTRESS	ACTRESS	an0053796	Coquette	tt0019788	Mary Pickford	Mary Pickford	nm0681933	True	Norma Besant	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930.
+2	1928/29	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053792	Thunderbolt	tt0020499	George Bancroft	George Bancroft	nm0051628		Thunderbolt Jim Lang	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053791	In Old Arizona	tt0020018	Warner Baxter	Warner Baxter	nm0062828	True	The Cisco Kid	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930.
+2	1928/29	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053793	Alibi	tt0019630	Chester Morris	Chester Morris	nm0606431		No. 1065, Chick Williams	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053794	The Valiant	tt0020543	Paul Muni	Paul Muni	nm0612847		James Dyke	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053795	The Patriot	tt0019257	Lewis Stone	Lewis Stone	nm0832011		Count Pahlen	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053797	Madame X	tt0020126	Ruth Chatterton	Ruth Chatterton	nm0154183		Jacqueline Floriot	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053798	The Barker	tt0018674	Betty Compson	Betty Compson	nm0173993		Carrie	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053799	The Letter	tt0020092	Jeanne Eagels	Jeanne Eagels	nm0247074		Leslie Crosbie	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053800	The Divine Lady	tt0019824	Corinne Griffith	Corinne Griffith	nm0341464		Emma Hart, Lady Hamilton	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053801	The Broadway Melody	tt0019729	Bessie Love	Bessie Love	nm0522281		Hank Mahoney	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053796	Coquette	tt0019788	Mary Pickford	Mary Pickford	nm0681933	True	Norma Besant	NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930.
 2	1928/29	Production	ART DIRECTION	ART DIRECTION	an0053832	The Patriot	tt0019257	Hans Dreier	Hans Dreier	nm0237417			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
 2	1928/29	Production	ART DIRECTION	ART DIRECTION	an0053826	The Bridge of San Luis Rey	tt0019722	Cedric Gibbons	Cedric Gibbons	nm0316539	True		NOTE: The award citation reads 'for 'The Bridge of San Luis Rey' and other pictures.' THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930.
 2	1928/29	Production	ART DIRECTION	ART DIRECTION	an0053829	Dynamite	tt0019843	Mitchell Leisen	Mitchell Leisen	nm0500552			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
@@ -75,32 +75,32 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 2	1928/29	Title	BEST PICTURE	OUTSTANDING PICTURE	an0053786	The Broadway Melody	tt0019729	Metro-Goldwyn-Mayer	Metro-Goldwyn-Mayer	co0007143	True		NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930.
 2	1928/29	Title	BEST PICTURE	OUTSTANDING PICTURE	an0053788	Hollywood Revue	tt0019993	Metro-Goldwyn-Mayer	Metro-Goldwyn-Mayer	co0007143			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
 2	1928/29	Title	BEST PICTURE	OUTSTANDING PICTURE	an0053790	The Patriot	tt0019257	Paramount Famous Lasky	Paramount Famous Lasky	co0023400			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053811	In Old Arizona	tt0020018	Tom Barry	Tom Barry	nm0058179			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053817	The Valiant	tt0020543	Tom Barry	Tom Barry	nm0058179			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053810	The Cop	tt0018792	Elliott Clawson	Elliott Clawson	nm0165470			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053813	The Leatherneck	tt0020088	Elliott Clawson	Elliott Clawson	nm0165470			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053815	Sal of Singapore	tt0019348	Elliott Clawson	Elliott Clawson	nm0165470			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053816	Skyscraper	tt0019398	Elliott Clawson	Elliott Clawson	nm0165470			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053812	The Last of Mrs. Cheyney	tt0020081	Hans Kraly	Hans Kraly	nm0473134			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053809	The Patriot	tt0019257	Hans Kraly	Hans Kraly	nm0473134	True		NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930.
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053814	Our Dancing Daughters	tt0019237	Josephine Lovett	Josephine Lovett	nm0522674			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053818	A Woman of Affairs	tt0019591	Bess Meredyth	Bess Meredyth	nm0580648			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
-2	1928/29	Writing	WRITING (Screenplay)	WRITING	an0053819	Wonder of Women	tt0020603	Bess Meredyth	Bess Meredyth	nm0580648			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
-3	1929/30	Acting	ACTOR	ACTOR	an0053839	Disraeli	tt0019823	George Arliss	George Arliss	nm0002183	True	Benjamin Disraeli	NOTE: As allowed by the award rules for this year, a single nomination could honor work in one or more films. Though the final awards ballot listed both Disraeli and The Green Goddess in his nomination, the award was announced for only the Disraeli performance. It has never been established as to why this was, but it possibly could have been because the original report from the Acting Branch Board of Judges only listed the Disraeli performance in the results of the nominations voting, or it could have been because on some of the final ballots, the voters had indicated the Disraeli performance over the other.
-3	1929/30	Acting	ACTOR	ACTOR	an0053840	The Green Goddess	tt0020938	George Arliss	George Arliss	nm0002183		Oxonian, the Rajah of Rukh	NOTE: As allowed by the award rules for this year, a single nomination could honor work in one or more films. Though the final awards ballot listed both Disraeli and The Green Goddess in his nomination, the award was announced for only the Disraeli performance. It has never been established as to why this was, but it possibly could have been because the original report from the Acting Branch Board of Judges only listed the Disraeli performance in the results of the nominations voting, or it could have been because on some of the final ballots, the voters had indicated the Disraeli performance over the other.
-3	1929/30	Acting	ACTOR	ACTOR	an0053841	The Big House	tt0020686	Wallace Beery	Wallace Beery	nm0000891		'Machine Gun' Butch Schmidt
-3	1929/30	Acting	ACTOR	ACTOR	an0053842	The Big Pond	tt0020690	Maurice Chevalier	Maurice Chevalier	nm0002001		Pierre Mirande			True
-3	1929/30	Acting	ACTOR	ACTOR	an0053843	The Love Parade	tt0020112	Maurice Chevalier	Maurice Chevalier	nm0002001		Count Alfred Renard			True
-3	1929/30	Acting	ACTOR	ACTOR	an0053844	Bulldog Drummond	tt0019735	Ronald Colman	Ronald Colman	nm0172903		Hugh 'Bulldog' Drummond			True
-3	1929/30	Acting	ACTOR	ACTOR	an0053845	Condemned	tt0019785	Ronald Colman	Ronald Colman	nm0172903		Michel			True
-3	1929/30	Acting	ACTOR	ACTOR	an0053846	The Rogue Song	tt0021307	Lawrence Tibbett	Lawrence Tibbett	nm0862546		Yegor
-3	1929/30	Acting	ACTRESS	ACTRESS	an0053848	The Devil's Holiday	tt0020823	Nancy Carroll	Nancy Carroll	nm0007216		Hallie Hobart
-3	1929/30	Acting	ACTRESS	ACTRESS	an0053849	Sarah and Son	tt0021335	Ruth Chatterton	Ruth Chatterton	nm0154183		Sarah Storm
-3	1929/30	Acting	ACTRESS	ACTRESS	an0053850	Anna Christie	tt0020641	Greta Garbo	Greta Garbo	nm0001256		Anna Christie			True
-3	1929/30	Acting	ACTRESS	ACTRESS	an0053851	Romance	tt0021310	Greta Garbo	Greta Garbo	nm0001256		Madame Rita Cavallini			True
-3	1929/30	Acting	ACTRESS	ACTRESS	an0053847	The Divorcee	tt0020827	Norma Shearer	Norma Shearer	nm0790454	True	Jerry	NOTE: As allowed by the award rules for this year, a single nomination could honor work in one or more films. Though the final awards ballot listed both The Divorcee and Their Own Desire in her nomination, the award was announced for only the The Divorcee performance. It has never been established as to why this was, but it possibly could have been because the original report from the Acting Branch Board of Judges only listed The Divorcee performance in the results of the nominations voting, or it could have been because on some of the final ballots, the voters had indicated the The Divorcee performance over the other.
-3	1929/30	Acting	ACTRESS	ACTRESS	an0053852	Their Own Desire	tt0020488	Norma Shearer	Norma Shearer	nm0790454		Lucia 'Lally' Marlett	NOTE: As allowed by the award rules for this year, a single nomination could honor work in one or more films. Though the final awards ballot listed both The Divorcee and Their Own Desire in her nomination, the award was announced for only the The Divorcee performance. It has never been established as to why this was, but it possibly could have been because the original report from the Acting Branch Board of Judges only listed The Divorcee performance in the results of the nominations voting, or it could have been because on some of the final ballots, the voters had indicated the The Divorcee performance over the other.
-3	1929/30	Acting	ACTRESS	ACTRESS	an0053853	The Trespasser	tt0020514	Gloria Swanson	Gloria Swanson	nm0841797		Marion Donnell
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053811	In Old Arizona	tt0020018	Tom Barry	Tom Barry	nm0058179			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053817	The Valiant	tt0020543	Tom Barry	Tom Barry	nm0058179			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053810	The Cop	tt0018792	Elliott Clawson	Elliott Clawson	nm0165470			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053813	The Leatherneck	tt0020088	Elliott Clawson	Elliott Clawson	nm0165470			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053815	Sal of Singapore	tt0019348	Elliott Clawson	Elliott Clawson	nm0165470			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053816	Skyscraper	tt0019398	Elliott Clawson	Elliott Clawson	nm0165470			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053812	The Last of Mrs. Cheyney	tt0020081	Hans Kraly	Hans Kraly	nm0473134			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053809	The Patriot	tt0019257	Hans Kraly	Hans Kraly	nm0473134	True		NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930.
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053814	Our Dancing Daughters	tt0019237	Josephine Lovett	Josephine Lovett	nm0522674			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053818	A Woman of Affairs	tt0019591	Bess Meredyth	Bess Meredyth	nm0580648			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
+2	1928/29	Writing	WRITING (Adapted Screenplay)	WRITING	an0053819	Wonder of Women	tt0020603	Bess Meredyth	Bess Meredyth	nm0580648			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. There were no announcements of nominations, no certificates of nomination or honorable mention, and only the winners (*) were revealed during the awards banquet on April 3, 1930. Though not official nominations, the additional names in each category, according to in-house records, were under consideration by the various boards of judges.		True
+3	1929/30	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053839	Disraeli	tt0019823	George Arliss	George Arliss	nm0002183	True	Benjamin Disraeli	NOTE: As allowed by the award rules for this year, a single nomination could honor work in one or more films. Though the final awards ballot listed both Disraeli and The Green Goddess in his nomination, the award was announced for only the Disraeli performance. It has never been established as to why this was, but it possibly could have been because the original report from the Acting Branch Board of Judges only listed the Disraeli performance in the results of the nominations voting, or it could have been because on some of the final ballots, the voters had indicated the Disraeli performance over the other.
+3	1929/30	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053840	The Green Goddess	tt0020938	George Arliss	George Arliss	nm0002183		Oxonian, the Rajah of Rukh	NOTE: As allowed by the award rules for this year, a single nomination could honor work in one or more films. Though the final awards ballot listed both Disraeli and The Green Goddess in his nomination, the award was announced for only the Disraeli performance. It has never been established as to why this was, but it possibly could have been because the original report from the Acting Branch Board of Judges only listed the Disraeli performance in the results of the nominations voting, or it could have been because on some of the final ballots, the voters had indicated the Disraeli performance over the other.
+3	1929/30	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053841	The Big House	tt0020686	Wallace Beery	Wallace Beery	nm0000891		'Machine Gun' Butch Schmidt
+3	1929/30	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053842	The Big Pond	tt0020690	Maurice Chevalier	Maurice Chevalier	nm0002001		Pierre Mirande			True
+3	1929/30	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053843	The Love Parade	tt0020112	Maurice Chevalier	Maurice Chevalier	nm0002001		Count Alfred Renard			True
+3	1929/30	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053844	Bulldog Drummond	tt0019735	Ronald Colman	Ronald Colman	nm0172903		Hugh 'Bulldog' Drummond			True
+3	1929/30	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053845	Condemned	tt0019785	Ronald Colman	Ronald Colman	nm0172903		Michel			True
+3	1929/30	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053846	The Rogue Song	tt0021307	Lawrence Tibbett	Lawrence Tibbett	nm0862546		Yegor
+3	1929/30	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053848	The Devil's Holiday	tt0020823	Nancy Carroll	Nancy Carroll	nm0007216		Hallie Hobart
+3	1929/30	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053849	Sarah and Son	tt0021335	Ruth Chatterton	Ruth Chatterton	nm0154183		Sarah Storm
+3	1929/30	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053850	Anna Christie	tt0020641	Greta Garbo	Greta Garbo	nm0001256		Anna Christie			True
+3	1929/30	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053851	Romance	tt0021310	Greta Garbo	Greta Garbo	nm0001256		Madame Rita Cavallini			True
+3	1929/30	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053847	The Divorcee	tt0020827	Norma Shearer	Norma Shearer	nm0790454	True	Jerry	NOTE: As allowed by the award rules for this year, a single nomination could honor work in one or more films. Though the final awards ballot listed both The Divorcee and Their Own Desire in her nomination, the award was announced for only the The Divorcee performance. It has never been established as to why this was, but it possibly could have been because the original report from the Acting Branch Board of Judges only listed The Divorcee performance in the results of the nominations voting, or it could have been because on some of the final ballots, the voters had indicated the The Divorcee performance over the other.
+3	1929/30	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053852	Their Own Desire	tt0020488	Norma Shearer	Norma Shearer	nm0790454		Lucia 'Lally' Marlett	NOTE: As allowed by the award rules for this year, a single nomination could honor work in one or more films. Though the final awards ballot listed both The Divorcee and Their Own Desire in her nomination, the award was announced for only the The Divorcee performance. It has never been established as to why this was, but it possibly could have been because the original report from the Acting Branch Board of Judges only listed The Divorcee performance in the results of the nominations voting, or it could have been because on some of the final ballots, the voters had indicated the The Divorcee performance over the other.
+3	1929/30	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053853	The Trespasser	tt0020514	Gloria Swanson	Gloria Swanson	nm0841797		Marion Donnell
 3	1929/30	Production	ART DIRECTION	ART DIRECTION	an0053871	Bulldog Drummond	tt0019735	(William Cameron Menzies)	William Cameron Menzies	nm0580017			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
 3	1929/30	Production	ART DIRECTION	ART DIRECTION	an0053870	King of Jazz	tt0021025	Herman Rosse	Herman Rosse	nm0743983	True
 3	1929/30	Production	ART DIRECTION	ART DIRECTION	an0053872	The Love Parade	tt0020112	(Hans Dreier)	Hans Dreier	nm0237417			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
@@ -127,21 +127,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 3	1929/30	Production	SOUND RECORDING	SOUND RECORDING	an0053877	The Love Parade	tt0020112	(Paramount Famous Lasky Studio Sound Department, Franklin Hansen, Sound Director)	Paramount Famous Lasky, Franklin Hansen	co0023400,nm0360630			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
 3	1929/30	Production	SOUND RECORDING	SOUND RECORDING	an0053878	Raffles	tt0021281	(United Artists Studio Sound Department, Oscar Lagerstrom, Sound Director)	United Artists, Oscar Lagerstrom	co0026841,nm0481264			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
 3	1929/30	Production	SOUND RECORDING	SOUND RECORDING	an0053879	Song of the Flame	tt0021404	(First National Studio Sound Department, George Groves, Sound Director)	First National, George Groves	co0041460,nm0344060			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
-3	1929/30	Writing	WRITING (Screenplay)	WRITING	an0053861	All Quiet on the Western Front	tt0020629	(George Abbott), (Maxwell Anderson), (Del Andrews)	George Abbott, Maxwell Anderson, Del Andrews	nm0007973,nm0027173,nm0028636			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
-3	1929/30	Writing	WRITING (Screenplay)	WRITING	an0053860	The Big House	tt0020686	Frances Marion	Frances Marion	nm0547966	True
-3	1929/30	Writing	WRITING (Screenplay)	WRITING	an0053862	Disraeli	tt0019823	(Julian Josephson)	Julian Josephson	nm0430756			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
-3	1929/30	Writing	WRITING (Screenplay)	WRITING	an0053863	The Divorcee	tt0020827	(John Meehan)	John Meehan	nm0576046			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
-3	1929/30	Writing	WRITING (Screenplay)	WRITING	an0053864	Street of Chance	tt0021420	(Howard Estabrook)	Howard Estabrook	nm0261455			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
-4	1930/31	Acting	ACTOR	ACTOR	an0050080	A Free Soul	tt0021885	Lionel Barrymore	Lionel Barrymore	nm0000859	True	Stephen Ashe
-4	1930/31	Acting	ACTOR	ACTOR	an0050081	Skippy	tt0022397	Jackie Cooper	Jackie Cooper	nm0178114		Skippy Skinner
-4	1930/31	Acting	ACTOR	ACTOR	an0050082	Cimarron	tt0021746	Richard Dix	Richard Dix	nm0228715		Yancey Cravat
-4	1930/31	Acting	ACTOR	ACTOR	an0050083	The Royal Family of Broadway	tt0021322	Fredric March	Fredric March	nm0545298		Tony Cavendish
-4	1930/31	Acting	ACTOR	ACTOR	an0050084	The Front Page	tt0021890	Adolphe Menjou	Adolphe Menjou	nm0579663		Walter Burns
-4	1930/31	Acting	ACTRESS	ACTRESS	an0050086	Morocco	tt0021156	Marlene Dietrich	Marlene Dietrich	nm0000017		Amy Jolly
-4	1930/31	Acting	ACTRESS	ACTRESS	an0050085	Min and Bill	tt0021148	Marie Dressler	Marie Dressler	nm0237597	True	Min
-4	1930/31	Acting	ACTRESS	ACTRESS	an0050087	Cimarron	tt0021746	Irene Dunne	Irene Dunne	nm0002050		Sabra Cravat
-4	1930/31	Acting	ACTRESS	ACTRESS	an0050088	Holiday	tt0020985	Ann Harding	Ann Harding	nm0362267		Linda Seton
-4	1930/31	Acting	ACTRESS	ACTRESS	an0050089	A Free Soul	tt0021885	Norma Shearer	Norma Shearer	nm0790454		Jan Ashe
+3	1929/30	Writing	WRITING (Adapted Screenplay)	WRITING	an0053861	All Quiet on the Western Front	tt0020629	(George Abbott), (Maxwell Anderson), (Del Andrews)	George Abbott, Maxwell Anderson, Del Andrews	nm0007973,nm0027173,nm0028636			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
+3	1929/30	Writing	WRITING (Adapted Screenplay)	WRITING	an0053860	The Big House	tt0020686	Frances Marion	Frances Marion	nm0547966	True
+3	1929/30	Writing	WRITING (Adapted Screenplay)	WRITING	an0053862	Disraeli	tt0019823	(Julian Josephson)	Julian Josephson	nm0430756			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
+3	1929/30	Writing	WRITING (Adapted Screenplay)	WRITING	an0053863	The Divorcee	tt0020827	(John Meehan)	John Meehan	nm0576046			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
+3	1929/30	Writing	WRITING (Adapted Screenplay)	WRITING	an0053864	Street of Chance	tt0021420	(Howard Estabrook)	Howard Estabrook	nm0261455			NOTE: For the third Academy Awards no certificates of nomination were given out in this category, only the titles of the nominated films and their companies were listed. When the winners were revealed, only the names of the individuals involved with the winning achievements were announced. The name(s) of those credited with this achievement are indicated here in parens.
+4	1930/31	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050080	A Free Soul	tt0021885	Lionel Barrymore	Lionel Barrymore	nm0000859	True	Stephen Ashe
+4	1930/31	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050081	Skippy	tt0022397	Jackie Cooper	Jackie Cooper	nm0178114		Skippy Skinner
+4	1930/31	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050082	Cimarron	tt0021746	Richard Dix	Richard Dix	nm0228715		Yancey Cravat
+4	1930/31	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050083	The Royal Family of Broadway	tt0021322	Fredric March	Fredric March	nm0545298		Tony Cavendish
+4	1930/31	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050084	The Front Page	tt0021890	Adolphe Menjou	Adolphe Menjou	nm0579663		Walter Burns
+4	1930/31	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050086	Morocco	tt0021156	Marlene Dietrich	Marlene Dietrich	nm0000017		Amy Jolly
+4	1930/31	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050085	Min and Bill	tt0021148	Marie Dressler	Marie Dressler	nm0237597	True	Min
+4	1930/31	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050087	Cimarron	tt0021746	Irene Dunne	Irene Dunne	nm0002050		Sabra Cravat
+4	1930/31	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050088	Holiday	tt0020985	Ann Harding	Ann Harding	nm0362267		Linda Seton
+4	1930/31	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050089	A Free Soul	tt0021885	Norma Shearer	Norma Shearer	nm0790454		Jan Ashe
 4	1930/31	Production	ART DIRECTION	ART DIRECTION	an0050110	Cimarron	tt0021746	Max Rée	Max Rée	nm0753663	True
 4	1930/31	Production	ART DIRECTION	ART DIRECTION	an0050111	Just Imagine	tt0021016	Stephen Goosson, Ralph Hammeras	Stephen Goosson, Ralph Hammeras	nm0329684,nm0358518
 4	1930/31	Production	ART DIRECTION	ART DIRECTION	an0050112	Morocco	tt0021156	Hans Dreier	Hans Dreier	nm0237417
@@ -182,12 +182,12 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 4	1930/31	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Electrical Research Products Inc.		True	Sound		To ELECTRICAL RESEARCH PRODUCTS, INC. for moving coil microphone transmitters.
 4	1930/31	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Rko Radio Pictures		True	Sound		To RKO RADIO PICTURES, INC. for reflex type microphone concentrators.
 4	1930/31	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Rca-Photophone Inc.		True	Sound		To RCA-PHOTOPHONE, INC. for ribbon microphone transmitters.
-5	1931/32	Acting	ACTOR	ACTOR	an0053438	The Champ	tt0021730	Wallace Beery	Wallace Beery	nm0000891	True	Champ	NOTE: A tie. Mr. Beery had one vote less than Fredric March (Dr. Jekyll and Mr. Hyde), and rules at the time stated that if any achievement came within three votes of the First Award, it would be considered a tie.
-5	1931/32	Acting	ACTOR	ACTOR	an0053440	The Guardsman	tt0021931	Alfred Lunt	Alfred Lunt	nm0526795		The Actor
-5	1931/32	Acting	ACTOR	ACTOR	an0053439	Dr. Jekyll and Mr. Hyde	tt0022835	Fredric March	Fredric March	nm0545298	True	Dr. Henry Jekyll/Mr. Hyde	NOTE: A tie. Wallace Beery (The Champ) had one vote less than Mr. March, and rules at the time stated that if any achievement came within three votes of the First Award, it would be considered a tie.
-5	1931/32	Acting	ACTRESS	ACTRESS	an0053442	Emma	tt0022854	Marie Dressler	Marie Dressler	nm0237597		Emma
-5	1931/32	Acting	ACTRESS	ACTRESS	an0053443	The Guardsman	tt0021931	Lynn Fontanne	Lynn Fontanne	nm0285007		The Actress
-5	1931/32	Acting	ACTRESS	ACTRESS	an0053441	The Sin of Madelon Claudet	tt0022386	Helen Hayes	Helen Hayes	nm0371040	True	Madelon
+5	1931/32	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053438	The Champ	tt0021730	Wallace Beery	Wallace Beery	nm0000891	True	Champ	NOTE: A tie. Mr. Beery had one vote less than Fredric March (Dr. Jekyll and Mr. Hyde), and rules at the time stated that if any achievement came within three votes of the First Award, it would be considered a tie.
+5	1931/32	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053440	The Guardsman	tt0021931	Alfred Lunt	Alfred Lunt	nm0526795		The Actor
+5	1931/32	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053439	Dr. Jekyll and Mr. Hyde	tt0022835	Fredric March	Fredric March	nm0545298	True	Dr. Henry Jekyll/Mr. Hyde	NOTE: A tie. Wallace Beery (The Champ) had one vote less than Mr. March, and rules at the time stated that if any achievement came within three votes of the First Award, it would be considered a tie.
+5	1931/32	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053442	Emma	tt0022854	Marie Dressler	Marie Dressler	nm0237597		Emma
+5	1931/32	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053443	The Guardsman	tt0021931	Lynn Fontanne	Lynn Fontanne	nm0285007		The Actress
+5	1931/32	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053441	The Sin of Madelon Claudet	tt0022386	Helen Hayes	Helen Hayes	nm0371040	True	Madelon
 5	1931/32	Production	ART DIRECTION	ART DIRECTION	an0053458	À Nous la Liberté	tt0022599	Lazare Meerson	Lazare Meerson	nm0576226
 5	1931/32	Production	ART DIRECTION	ART DIRECTION	an0053459	Arrowsmith	tt0021622	Richard Day	Richard Day	nm0206554
 5	1931/32	Production	ART DIRECTION	ART DIRECTION	an0053457	Transatlantic	tt0022500	Gordon Wiles	Gordon Wiles	nm0928781	True
@@ -229,12 +229,12 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 5	1931/32	Special	SPECIAL AWARD	SPECIAL AWARD	an0051402				Walt Disney	nm0000370	True			To Walt Disney for the creation of \"Mickey Mouse.\"
 5	1931/32	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Technicolor Motion Picture Corp.		True	Cartoon Process		To TECHNICOLOR MOTION PICTURE CORP. for its color cartoon process.
 5	1931/32	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Eastman Kodak Company		True	Laboratory		To EASTMAN KODAK COMPANY for its Type II-B Sensitometer.
-6	1932/33	Acting	ACTOR	ACTOR	an0052208	Berkeley Square	tt0023794	Leslie Howard	Leslie Howard	nm0001366		Peter Standish	came in 3rd
-6	1932/33	Acting	ACTOR	ACTOR	an0052207	The Private Life of Henry VIII	tt0024473	Charles Laughton	Charles Laughton	nm0001452	True	Henry VIII
-6	1932/33	Acting	ACTOR	ACTOR	an0052209	I Am a Fugitive from a Chain Gang	tt0023042	Paul Muni	Paul Muni	nm0612847		James Allen	came in 2nd
-6	1932/33	Acting	ACTRESS	ACTRESS	an0052210	Morning Glory	tt0024353	Katharine Hepburn	Katharine Hepburn	nm0000031	True	Eva Lovelace
-6	1932/33	Acting	ACTRESS	ACTRESS	an0052211	Lady for a Day	tt0024240	May Robson	May Robson	nm0733480		Apple Annie	came in 2nd
-6	1932/33	Acting	ACTRESS	ACTRESS	an0052212	Cavalcade	tt0023876	Diana Wynyard	Diana Wynyard	nm0944087		Jane Marryot	came in 3rd
+6	1932/33	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052208	Berkeley Square	tt0023794	Leslie Howard	Leslie Howard	nm0001366		Peter Standish	came in 3rd
+6	1932/33	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052207	The Private Life of Henry VIII	tt0024473	Charles Laughton	Charles Laughton	nm0001452	True	Henry VIII
+6	1932/33	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052209	I Am a Fugitive from a Chain Gang	tt0023042	Paul Muni	Paul Muni	nm0612847		James Allen	came in 2nd
+6	1932/33	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052210	Morning Glory	tt0024353	Katharine Hepburn	Katharine Hepburn	nm0000031	True	Eva Lovelace
+6	1932/33	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052211	Lady for a Day	tt0024240	May Robson	May Robson	nm0733480		Apple Annie	came in 2nd
+6	1932/33	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052212	Cavalcade	tt0023876	Diana Wynyard	Diana Wynyard	nm0944087		Jane Marryot	came in 3rd
 6	1932/33	Production	ART DIRECTION	ART DIRECTION	an0052225	Cavalcade	tt0023876	William S. Darling	William S. Darling	nm0201419	True
 6	1932/33	Production	ART DIRECTION	ART DIRECTION	an0052226	A Farewell to Arms	tt0022879	Hans Dreier, Roland Anderson	Hans Dreier, Roland Anderson	nm0237417,nm0027380			came in 2nd
 6	1932/33	Production	ART DIRECTION	ART DIRECTION	an0052227	When Ladies Meet	tt0024763	Cedric Gibbons	Cedric Gibbons	nm0316539			came in 3rd
@@ -294,13 +294,13 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 6	1932/33	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Electrical Research Products		True	Sound		To ELECTRICAL RESEARCH PRODUCTS, INC. for their wide range recording and reproducing system.
 6	1932/33	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Rca-Victor Company Inc.		True	Sound		To RCA-VICTOR COMPANY, INC. for their high-fidelity recording and reproducing system.
 6	1932/33	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0049539				Fox Film Corporation, FRED JACKMAN, WARNER BROS. PICTURES INC., SIDNEY SANDERS	?,nm0413164,?,nm0766961	True	Special Photographic		To FOX FILM CORPORATION, FRED JACKMAN and WARNER BROS. PICTURES, INC., and SIDNEY SANDERS of RKO Studios, Inc., for their development and effective use of the translucent cellulose screen in composite photography.
-7	1934	Acting	ACTOR	ACTOR	an0056489	It Happened One Night	tt0025316	Clark Gable	Clark Gable	nm0000022	True	Peter Warne
-7	1934	Acting	ACTOR	ACTOR	an0056490	The Affairs of Cellini	tt0024816	Frank Morgan	Frank Morgan	nm0604656		Allesandro, Duke of Florence	came in 2nd
-7	1934	Acting	ACTOR	ACTOR	an0056491	The Thin Man	tt0025878	William Powell	William Powell	nm0001635		Nick Charles	came in 3rd
-7	1934	Acting	ACTRESS	ACTRESS	an0056492	It Happened One Night	tt0025316	Claudette Colbert	Claudette Colbert	nm0001055	True	Ellie Andrews
-7	1934	Acting	ACTRESS	ACTRESS	an0056495	Of Human Bondage	tt0025586	Bette Davis	Bette Davis	nm0000012		Mildred	came in 3rd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
-7	1934	Acting	ACTRESS	ACTRESS	an0056493	One Night of Love	tt0025601	Grace Moore	Grace Moore	nm0601254		Mary
-7	1934	Acting	ACTRESS	ACTRESS	an0056494	The Barretts of Wimpole Street	tt0024865	Norma Shearer	Norma Shearer	nm0790454		Elizabeth Barrett	came in 2nd
+7	1934	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056489	It Happened One Night	tt0025316	Clark Gable	Clark Gable	nm0000022	True	Peter Warne
+7	1934	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056490	The Affairs of Cellini	tt0024816	Frank Morgan	Frank Morgan	nm0604656		Allesandro, Duke of Florence	came in 2nd
+7	1934	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056491	The Thin Man	tt0025878	William Powell	William Powell	nm0001635		Nick Charles	came in 3rd
+7	1934	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056492	It Happened One Night	tt0025316	Claudette Colbert	Claudette Colbert	nm0001055	True	Ellie Andrews
+7	1934	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056495	Of Human Bondage	tt0025586	Bette Davis	Bette Davis	nm0000012		Mildred	came in 3rd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
+7	1934	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056493	One Night of Love	tt0025601	Grace Moore	Grace Moore	nm0601254		Mary
+7	1934	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056494	The Barretts of Wimpole Street	tt0024865	Norma Shearer	Norma Shearer	nm0790454		Elizabeth Barrett	came in 2nd
 7	1934	Production	ART DIRECTION	ART DIRECTION	an0056509	The Affairs of Cellini	tt0024816	Richard Day	Richard Day	nm0206554			came in 3rd
 7	1934	Production	ART DIRECTION	ART DIRECTION	an0056510	The Gay Divorcee	tt0025164	Van Nest Polglase, Carroll Clark	Van Nest Polglase, Carroll Clark	nm0689026,nm0163754			came in 2nd
 7	1934	Production	ART DIRECTION	ART DIRECTION	an0056508	The Merry Widow	tt0025493	Cedric Gibbons, Fredric Hope	Cedric Gibbons, Fredric Hope	nm0316539,nm0393978	True		NOTE: won by two votes
@@ -316,9 +316,9 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 7	1934	Production	FILM EDITING	FILM EDITING	an0056520	Cleopatra	tt0024991	Anne Bauchens	Anne Bauchens	nm0061640			came in 3rd
 7	1934	Production	FILM EDITING	FILM EDITING	an0056519	Eskimo	tt0023990	Conrad Nervig	Conrad Nervig	nm0626308	True
 7	1934	Production	FILM EDITING	FILM EDITING	an0056521	One Night of Love	tt0025601	Gene Milford	Gene Milford	nm0587332			came in 2nd
-7	1934	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0056529	The Gay Divorcee	tt0025164	RKO Radio Studio Music Department, Max Steiner, head of department (Score by Kenneth Webb and Samuel Hoffenstein)	RKO Radio, Max Steiner, Kenneth Webb, Samuel Hoffenstein	co0041421,nm0000070,nm0916177,nm0388755			came in 2nd
-7	1934	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0056530	The Lost Patrol	tt0025423	RKO Radio Studio Music Department, Max Steiner, head of department (Score by Max Steiner)	RKO Radio, Max Steiner	co0041421,nm0000070			came in 3rd
-7	1934	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0056528	One Night of Love	tt0025601	Columbia Studio Music Department, Louis Silvers, head of department (Thematic Music by Victor Schertzinger and Gus Kahn)	Columbia, Louis Silvers, Victor Schertzinger, Gus Kahn	co0050868,nm0799007,nm0006276,nm0006146	True
+7	1934	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0056529	The Gay Divorcee	tt0025164	RKO Radio Studio Music Department, Max Steiner, head of department (Score by Kenneth Webb and Samuel Hoffenstein)	RKO Radio, Max Steiner, Kenneth Webb, Samuel Hoffenstein	co0041421,nm0000070,nm0916177,nm0388755			came in 2nd
+7	1934	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0056530	The Lost Patrol	tt0025423	RKO Radio Studio Music Department, Max Steiner, head of department (Score by Max Steiner)	RKO Radio, Max Steiner	co0041421,nm0000070			came in 3rd
+7	1934	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0056528	One Night of Love	tt0025601	Columbia Studio Music Department, Louis Silvers, head of department (Thematic Music by Victor Schertzinger and Gus Kahn)	Columbia, Louis Silvers, Victor Schertzinger, Gus Kahn	co0050868,nm0799007,nm0006276,nm0006146	True
 7	1934	Music	MUSIC (Original Song)	MUSIC (Song)	an0056526	Flying Down to Rio	tt0024025	Music by Vincent Youmans; Lyrics by Edward Eliscu and Gus Kahn	Vincent Youmans, Edward Eliscu, Gus Kahn	nm0949207,nm0253697,nm0006146		Carioca	came in 3rd
 7	1934	Music	MUSIC (Original Song)	MUSIC (Song)	an0056525	The Gay Divorcee	tt0025164	Music by Con Conrad; Lyrics by Herb Magidson	Con Conrad, Herb Magidson	nm0175628,nm0536054	True	The Continental
 7	1934	Music	MUSIC (Original Song)	MUSIC (Song)	an0056527	She Loves Me Not	tt0025774	Music by Ralph Rainger; Lyrics by Leo Robin	Ralph Rainger, Leo Robin	nm0006247,nm0732209		Love In Bloom	came in 2nd
@@ -361,17 +361,17 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 7	1934	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Electrical Research Products		True	Sound		To ELECTRICAL RESEARCH PRODUCTS, INC. for their development of the Vertical Cut Disc Method of recording sound for motion pictures (hill and dale recording).
 7	1934	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0047705	One Night of Love	tt0025601		Columbia Pictures Corporation	co0050868	True	Sound		To COLUMBIA PICTURES CORPORATION for their application of the Vertical Cut Disc Method (hill and dale recording) to actual studio production, with their recording of the sound on the picture One Night of Love.
 7	1934	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Bell And Howell Company		True	Laboratory		To BELL AND HOWELL COMPANY for their development of the Bell and Howell Fully Automatic Sound and Picture Printer.
-8	1935	Acting	ACTOR	ACTOR	an0050243	Mutiny on the Bounty	tt0026752	Clark Gable	Clark Gable	nm0000022		Fletcher Christian
-8	1935	Acting	ACTOR	ACTOR	an0050244	Mutiny on the Bounty	tt0026752	Charles Laughton	Charles Laughton	nm0001452		Captain Bligh	came in 3rd
-8	1935	Acting	ACTOR	ACTOR	an0050242	The Informer	tt0026529	Victor McLaglen	Victor McLaglen	nm0572142	True	Gypo Nolan
-8	1935	Acting	ACTOR	ACTOR	an0050246	Black Fury	tt0026121	Paul Muni	Paul Muni	nm0612847		Joe Radek	came in 2nd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
-8	1935	Acting	ACTOR	ACTOR	an0050245	Mutiny on the Bounty	tt0026752	Franchot Tone	Franchot Tone	nm0867144		Roger Byam
-8	1935	Acting	ACTRESS	ACTRESS	an0050248	Escape Me Never	tt0026320	Elisabeth Bergner	Elisabeth Bergner	nm0074949		Gemma Jones	came in 3rd
-8	1935	Acting	ACTRESS	ACTRESS	an0050249	Private Worlds	tt0026893	Claudette Colbert	Claudette Colbert	nm0001055		Jane Everest
-8	1935	Acting	ACTRESS	ACTRESS	an0050247	Dangerous	tt0026261	Bette Davis	Bette Davis	nm0000012	True	Joyce Heath
-8	1935	Acting	ACTRESS	ACTRESS	an0050250	Alice Adams	tt0026056	Katharine Hepburn	Katharine Hepburn	nm0000031		Alice Adams	came in 2nd
-8	1935	Acting	ACTRESS	ACTRESS	an0050251	Becky Sharp	tt0026104	Miriam Hopkins	Miriam Hopkins	nm0394244		Becky Sharp
-8	1935	Acting	ACTRESS	ACTRESS	an0050252	The Dark Angel	tt0026264	Merle Oberon	Merle Oberon	nm0643353		Kitty Vane
+8	1935	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050243	Mutiny on the Bounty	tt0026752	Clark Gable	Clark Gable	nm0000022		Fletcher Christian
+8	1935	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050244	Mutiny on the Bounty	tt0026752	Charles Laughton	Charles Laughton	nm0001452		Captain Bligh	came in 3rd
+8	1935	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050242	The Informer	tt0026529	Victor McLaglen	Victor McLaglen	nm0572142	True	Gypo Nolan
+8	1935	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050246	Black Fury	tt0026121	Paul Muni	Paul Muni	nm0612847		Joe Radek	came in 2nd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
+8	1935	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050245	Mutiny on the Bounty	tt0026752	Franchot Tone	Franchot Tone	nm0867144		Roger Byam
+8	1935	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050248	Escape Me Never	tt0026320	Elisabeth Bergner	Elisabeth Bergner	nm0074949		Gemma Jones	came in 3rd
+8	1935	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050249	Private Worlds	tt0026893	Claudette Colbert	Claudette Colbert	nm0001055		Jane Everest
+8	1935	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050247	Dangerous	tt0026261	Bette Davis	Bette Davis	nm0000012	True	Joyce Heath
+8	1935	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050250	Alice Adams	tt0026056	Katharine Hepburn	Katharine Hepburn	nm0000031		Alice Adams	came in 2nd
+8	1935	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050251	Becky Sharp	tt0026104	Miriam Hopkins	Miriam Hopkins	nm0394244		Becky Sharp
+8	1935	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050252	The Dark Angel	tt0026264	Merle Oberon	Merle Oberon	nm0643353		Kitty Vane
 8	1935	Production	ART DIRECTION	ART DIRECTION	an0050269	The Dark Angel	tt0026264	Richard Day	Richard Day	nm0206554	True
 8	1935	Production	ART DIRECTION	ART DIRECTION	an0050270	The Lives of a Bengal Lancer	tt0026643	Hans Dreier, Roland Anderson	Hans Dreier, Roland Anderson	nm0237417,nm0027380			came in 3rd
 8	1935	Production	ART DIRECTION	ART DIRECTION	an0050271	Top Hat	tt0027125	Van Nest Polglase, Carroll Clark	Van Nest Polglase, Carroll Clark	nm0689026,nm0163754			came in 2nd
@@ -403,10 +403,10 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 8	1935	Production	FILM EDITING	FILM EDITING	an0050285	The Lives of a Bengal Lancer	tt0026643	Ellsworth Hoagland	Ellsworth Hoagland	nm0387449
 8	1935	Production	FILM EDITING	FILM EDITING	an0050281	A Midsummer Night's Dream	tt0026714	Ralph Dawson	Ralph Dawson	nm0206238	True
 8	1935	Production	FILM EDITING	FILM EDITING	an0050286	Mutiny on the Bounty	tt0026752	Margaret Booth	Margaret Booth	nm0004290			came in 2nd
-8	1935	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0050308	Captain Blood	tt0026174	Warner Bros.-First National Studio Music Department, Leo Forbstein, head of department (Score by Erich Wolfgang Korngold)	Warner Bros., First National, Leo Forbstein, Erich Wolfgang Korngold	co0080422,co0041460,nm0006079,nm0006157			came in 3rd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
-8	1935	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0050305	The Informer	tt0026529	RKO Radio Studio Music Department, Max Steiner, head of department (Score by Max Steiner)	RKO Radio, Max Steiner	co0041421,nm0000070	True
-8	1935	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0050306	Mutiny on the Bounty	tt0026752	Metro-Goldwyn-Mayer Studio Music Department, Nat W. Finston, head of department (Score by Herbert Stothart)	Metro-Goldwyn-Mayer, Nat W. Finston, Herbert Stothart	co0007143,nm0278358,nm0006307			came in 2nd
-8	1935	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0050307	Peter Ibbetson	tt0026866	Paramount Studio Music Department, Irvin Talbot, head of department (Score by Ernst Toch)	Paramount, Irvin Talbot, Ernst Toch	co0023400,nm0847913,nm0006324
+8	1935	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0050308	Captain Blood	tt0026174	Warner Bros.-First National Studio Music Department, Leo Forbstein, head of department (Score by Erich Wolfgang Korngold)	Warner Bros., First National, Leo Forbstein, Erich Wolfgang Korngold	co0080422,co0041460,nm0006079,nm0006157			came in 3rd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
+8	1935	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0050305	The Informer	tt0026529	RKO Radio Studio Music Department, Max Steiner, head of department (Score by Max Steiner)	RKO Radio, Max Steiner	co0041421,nm0000070	True
+8	1935	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0050306	Mutiny on the Bounty	tt0026752	Metro-Goldwyn-Mayer Studio Music Department, Nat W. Finston, head of department (Score by Herbert Stothart)	Metro-Goldwyn-Mayer, Nat W. Finston, Herbert Stothart	co0007143,nm0278358,nm0006307			came in 2nd
+8	1935	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0050307	Peter Ibbetson	tt0026866	Paramount Studio Music Department, Irvin Talbot, head of department (Score by Ernst Toch)	Paramount, Irvin Talbot, Ernst Toch	co0023400,nm0847913,nm0006324
 8	1935	Music	MUSIC (Original Song)	MUSIC (Song)	an0050303	Top Hat	tt0027125	Music and Lyrics by Irving Berlin	Irving Berlin	nm0000927		Cheek To Cheek	came in 2nd
 8	1935	Music	MUSIC (Original Song)	MUSIC (Song)	an0050304	Roberta	tt0026942	Music by Jerome Kern; Lyrics by Dorothy Fields and Jimmy McHugh	Jerome Kern, Dorothy Fields, Jimmy McHugh	nm0006153,nm0276227,nm0006192		Lovely To Look At	came in 3rd
 8	1935	Music	MUSIC (Original Song)	MUSIC (Song)	an0050302	Gold Diggers of 1935	tt0026421	Music by Harry Warren; Lyrics by Al Dubin	Harry Warren, Al Dubin	nm0912851,nm0006048	True	Lullaby Of Broadway
@@ -444,10 +444,10 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 8	1935	Writing	WRITING (Original Story)	WRITING (Original Story)	an0050260	G-Men	tt0026393	Gregory Rogers	Gregory Rogers	nm0953123			came in 2nd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
 8	1935	Writing	WRITING (Original Story)	WRITING (Original Story)	an0050259	The Gay Deception	tt0026400	Don Hartman, Stephen Avery	Don Hartman, Stephen Avery	nm0366942,nm0043081
 8	1935	Writing	WRITING (Original Story)	WRITING (Original Story)	an0050257	The Scoundrel	tt0026970	Ben Hecht, Charles MacArthur	Ben Hecht, Charles MacArthur	nm0372942,nm0531269	True
-8	1935	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050264	Captain Blood	tt0026174	Casey Robinson	Casey Robinson	nm0732452			came in 3rd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
-8	1935	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050261	The Informer	tt0026529	Dudley Nichols	Dudley Nichols	nm0629580	True		NOTE: Mr. Nichols initially refused the award, but Academy records indicate that he was in possession of a statuette by 1949.
-8	1935	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050262	The Lives of a Bengal Lancer	tt0026643	Screenplay by Waldemar Young, John L. Balderston, Achmed Abdullah; Adaptation by Grover Jones, William Slavens McNutt	Waldemar Young, John L. Balderston, Achmed Abdullah, Grover Jones, William Slavens McNutt	nm0950150,nm0049721,nm0008280,nm0428177,nm0574112
-8	1935	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050263	Mutiny on the Bounty	tt0026752	Talbot Jennings, Jules Furthman, Carey Wilson	Talbot Jennings, Jules Furthman, Carey Wilson	nm0421255,nm0299154,nm0933133			came in 2nd
+8	1935	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050264	Captain Blood	tt0026174	Casey Robinson	Casey Robinson	nm0732452			came in 3rd / NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Write-in candidate.
+8	1935	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050261	The Informer	tt0026529	Dudley Nichols	Dudley Nichols	nm0629580	True		NOTE: Mr. Nichols initially refused the award, but Academy records indicate that he was in possession of a statuette by 1949.
+8	1935	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050262	The Lives of a Bengal Lancer	tt0026643	Screenplay by Waldemar Young, John L. Balderston, Achmed Abdullah; Adaptation by Grover Jones, William Slavens McNutt	Waldemar Young, John L. Balderston, Achmed Abdullah, Grover Jones, William Slavens McNutt	nm0950150,nm0049721,nm0008280,nm0428177,nm0574112
+8	1935	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050263	Mutiny on the Bounty	tt0026752	Talbot Jennings, Jules Furthman, Carey Wilson	Talbot Jennings, Jules Furthman, Carey Wilson	nm0421255,nm0299154,nm0933133			came in 2nd
 8	1935	Special	SPECIAL AWARD	SPECIAL AWARD	an0047986				David Wark Griffith	nm0000428	True			To David Wark Griffith, for his distinguished creative achievements as director and producer and his invaluable initiative and lasting contributions to the progress of the motion picture arts.
 8	1935	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Agfa Ansco Corporation		True	Film		To AGFA ANSCO CORPORATION for their development of the Agfa infra-red film.
 8	1935	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Eastman Kodak Company		True	Lenses and Filters		To EASTMAN KODAK COMPANY for their development of the Eastman Pola-Screen.
@@ -458,21 +458,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 8	1935	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Electrical Research Products Inc.		True	Sound		To ELECTRICAL RESEARCH PRODUCTS, INC. for their study and development of equipment to analyze and measure flutter resulting from the travel of the film through the mechanisms used in the recording and reproduction of sound.
 8	1935	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Paramount Productions Inc.		True	Laboratory		To PARAMOUNT PRODUCTIONS, INC. for the design and construction of the Paramount transparency air turbine developing machine.
 8	1935	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0047996				Nathan Levinson	nm0506080	True	Sound		To NATHAN LEVINSON, Director of Sound Recording for Warner Bros.-First National Studio, for the method of intercutting variable density and variable area sound tracks to secure an increase in the effective volume range of sound recorded for motion pictures.
-9	1936	Acting	ACTOR	ACTOR	an0056266	Mr. Deeds Goes to Town	tt0027996	Gary Cooper	Gary Cooper	nm0000011		Longfellow Deeds
-9	1936	Acting	ACTOR	ACTOR	an0056267	Dodsworth	tt0027532	Walter Huston	Walter Huston	nm0404158		Sam Dodsworth
-9	1936	Acting	ACTOR	ACTOR	an0056265	The Story of Louis Pasteur	tt0028313	Paul Muni	Paul Muni	nm0612847	True	Louis Pasteur
-9	1936	Acting	ACTOR	ACTOR	an0056268	My Man Godfrey	tt0028010	William Powell	William Powell	nm0001635		Godfrey Parks
-9	1936	Acting	ACTOR	ACTOR	an0056269	San Francisco	tt0028216	Spencer Tracy	Spencer Tracy	nm0000075		Father Tim Mullen
+9	1936	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056266	Mr. Deeds Goes to Town	tt0027996	Gary Cooper	Gary Cooper	nm0000011		Longfellow Deeds
+9	1936	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056267	Dodsworth	tt0027532	Walter Huston	Walter Huston	nm0404158		Sam Dodsworth
+9	1936	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056265	The Story of Louis Pasteur	tt0028313	Paul Muni	Paul Muni	nm0612847	True	Louis Pasteur
+9	1936	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056268	My Man Godfrey	tt0028010	William Powell	William Powell	nm0001635		Godfrey Parks
+9	1936	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056269	San Francisco	tt0028216	Spencer Tracy	Spencer Tracy	nm0000075		Father Tim Mullen
 9	1936	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056276	My Man Godfrey	tt0028010	Mischa Auer	Mischa Auer	nm0041681		Carlo
 9	1936	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056275	Come and Get It	tt0027459	Walter Brennan	Walter Brennan	nm0000974	True	Swan Bostrom
 9	1936	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056277	Pigskin Parade	tt0028103	Stuart Erwin	Stuart Erwin	nm0260020		Amos Dodd
 9	1936	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056278	Romeo and Juliet	tt0028203	Basil Rathbone	Basil Rathbone	nm0001651		Tybalt
 9	1936	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056279	The General Died at Dawn	tt0027664	Akim Tamiroff	Akim Tamiroff	nm0848667		General Yang
-9	1936	Acting	ACTRESS	ACTRESS	an0056271	Theodora Goes Wild	tt0028355	Irene Dunne	Irene Dunne	nm0002050		Theodora Lynn
-9	1936	Acting	ACTRESS	ACTRESS	an0056272	Valiant Is the Word for Carrie	tt0028455	Gladys George	Gladys George	nm0313438		Carrie Snyder
-9	1936	Acting	ACTRESS	ACTRESS	an0056273	My Man Godfrey	tt0028010	Carole Lombard	Carole Lombard	nm0001479		Irene Bullock
-9	1936	Acting	ACTRESS	ACTRESS	an0056270	The Great Ziegfeld	tt0027698	Luise Rainer	Luise Rainer	nm0707023	True	Anna Held
-9	1936	Acting	ACTRESS	ACTRESS	an0056274	Romeo and Juliet	tt0028203	Norma Shearer	Norma Shearer	nm0790454		Juliet
+9	1936	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056271	Theodora Goes Wild	tt0028355	Irene Dunne	Irene Dunne	nm0002050		Theodora Lynn
+9	1936	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056272	Valiant Is the Word for Carrie	tt0028455	Gladys George	Gladys George	nm0313438		Carrie Snyder
+9	1936	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056273	My Man Godfrey	tt0028010	Carole Lombard	Carole Lombard	nm0001479		Irene Bullock
+9	1936	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056270	The Great Ziegfeld	tt0027698	Luise Rainer	Luise Rainer	nm0707023	True	Anna Held
+9	1936	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056274	Romeo and Juliet	tt0028203	Norma Shearer	Norma Shearer	nm0790454		Juliet
 9	1936	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056281	The Gorgeous Hussy	tt0027690	Beulah Bondi	Beulah Bondi	nm0094135		Rachel Jackson
 9	1936	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056282	My Man Godfrey	tt0028010	Alice Brady	Alice Brady	nm0103567		Angelica Bullock
 9	1936	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056283	These Three	tt0028356	Bonita Granville	Bonita Granville	nm0335748		Mary Tilford
@@ -511,11 +511,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 9	1936	Production	FILM EDITING	FILM EDITING	an0056322	Lloyds of London	tt0027902	Barbara McLean	Barbara McLean	nm0572492
 9	1936	Production	FILM EDITING	FILM EDITING	an0056323	A Tale of Two Cities	tt0027075	Conrad A. Nervig	Conrad A. Nervig	nm0626308
 9	1936	Production	FILM EDITING	FILM EDITING	an0056324	Theodora Goes Wild	tt0028355	Otto Meyer	Otto Meyer	nm0583301
-9	1936	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0056343	Anthony Adverse	tt0027300	Warner Bros. Studio Music Department, Leo Forbstein, head of department (Score by Erich Wolfgang Korngold)	Warner Bros., Leo Forbstein, Erich Wolfgang Korngold	co0080422,nm0006079,nm0006157	True
-9	1936	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0056344	The Charge of the Light Brigade	tt0027438	Warner Bros. Studio Music Department, Leo Forbstein, head of department (Score by Max Steiner)	Warner Bros., Leo Forbstein, Max Steiner	co0080422,nm0006079,nm0000070
-9	1936	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0056345	The Garden of Allah	tt0027657	Selznick International Pictures Music Department, Max Steiner, head of department (Score by Max Steiner)	Selznick International Pictures, Max Steiner	co0130901,nm0000070
-9	1936	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0056346	The General Died at Dawn	tt0027664	Paramount Studio Music Department, Boris Morros, head of department (Score by Werner Janssen)	Paramount, Boris Morros, Werner Janssen	co0023400,nm0607448,nm0418205
-9	1936	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0056347	Winterset	tt0028511	RKO Radio Studio Music Department, Nathaniel Shilkret, head of department (Score by Nathaniel Shilkret)	RKO Radio, Nathaniel Shilkret	co0041421,nm0006287
+9	1936	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0056343	Anthony Adverse	tt0027300	Warner Bros. Studio Music Department, Leo Forbstein, head of department (Score by Erich Wolfgang Korngold)	Warner Bros., Leo Forbstein, Erich Wolfgang Korngold	co0080422,nm0006079,nm0006157	True
+9	1936	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0056344	The Charge of the Light Brigade	tt0027438	Warner Bros. Studio Music Department, Leo Forbstein, head of department (Score by Max Steiner)	Warner Bros., Leo Forbstein, Max Steiner	co0080422,nm0006079,nm0000070
+9	1936	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0056345	The Garden of Allah	tt0027657	Selznick International Pictures Music Department, Max Steiner, head of department (Score by Max Steiner)	Selznick International Pictures, Max Steiner	co0130901,nm0000070
+9	1936	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0056346	The General Died at Dawn	tt0027664	Paramount Studio Music Department, Boris Morros, head of department (Score by Werner Janssen)	Paramount, Boris Morros, Werner Janssen	co0023400,nm0607448,nm0418205
+9	1936	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0056347	Winterset	tt0028511	RKO Radio Studio Music Department, Nathaniel Shilkret, head of department (Score by Nathaniel Shilkret)	RKO Radio, Nathaniel Shilkret	co0041421,nm0006287
 9	1936	Music	MUSIC (Original Song)	MUSIC (Song)	an0056338	Suzy	tt0028330	Music by Walter Donaldson; Lyrics by Harold Adamson	Walter Donaldson, Harold Adamson	nm0232164,nm0011488		Did I Remember
 9	1936	Music	MUSIC (Original Song)	MUSIC (Song)	an0056339	Born to Dance	tt0027387	Music and Lyrics by Cole Porter	Cole Porter	nm0006234		I've Got You Under My Skin
 9	1936	Music	MUSIC (Original Song)	MUSIC (Song)	an0056340	Trail of the Lonesome Pine	tt0028401	Music by Louis Alter; Lyrics by Sidney Mitchell	Louis Alter, Sidney Mitchell	nm0022746,nm0593733		A Melody From The Sky
@@ -558,11 +558,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 9	1936	Writing	WRITING (Original Story)	WRITING (Original Story)	an0056293	San Francisco	tt0028216	Robert Hopkins	Robert Hopkins	nm0394267
 9	1936	Writing	WRITING (Original Story)	WRITING (Original Story)	an0056290	The Story of Louis Pasteur	tt0028313	Pierre Collings, Sheridan Gibney	Pierre Collings, Sheridan Gibney	nm0172074,nm0316807	True
 9	1936	Writing	WRITING (Original Story)	WRITING (Original Story)	an0056294	Three Smart Girls	tt0028373	Adele Comandini	Adele Comandini	nm0173532
-9	1936	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056296	After the Thin Man	tt0027260	Frances Goodrich, Albert Hackett	Frances Goodrich, Albert Hackett	nm0329304,nm0352443
-9	1936	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056297	Dodsworth	tt0027532	Sidney Howard	Sidney Howard	nm0397608
-9	1936	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056298	Mr. Deeds Goes to Town	tt0027996	Robert Riskin	Robert Riskin	nm0728307
-9	1936	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056299	My Man Godfrey	tt0028010	Eric Hatch, Morris Ryskind	Eric Hatch, Morris Ryskind	nm0368719,nm0753452
-9	1936	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056295	The Story of Louis Pasteur	tt0028313	Pierre Collings, Sheridan Gibney	Pierre Collings, Sheridan Gibney	nm0172074,nm0316807	True
+9	1936	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056296	After the Thin Man	tt0027260	Frances Goodrich, Albert Hackett	Frances Goodrich, Albert Hackett	nm0329304,nm0352443
+9	1936	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056297	Dodsworth	tt0027532	Sidney Howard	Sidney Howard	nm0397608
+9	1936	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056298	Mr. Deeds Goes to Town	tt0027996	Robert Riskin	Robert Riskin	nm0728307
+9	1936	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056299	My Man Godfrey	tt0028010	Eric Hatch, Morris Ryskind	Eric Hatch, Morris Ryskind	nm0368719,nm0753452
+9	1936	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056295	The Story of Louis Pasteur	tt0028313	Pierre Collings, Sheridan Gibney	Pierre Collings, Sheridan Gibney	nm0172074,nm0316807	True
 9	1936	Special	SPECIAL AWARD	SPECIAL AWARD	anxxx000	The March of Time	tt3034436				True			To The March of Time for its significance to motion pictures and for having revolutionized one of the most important branches of the industry - the newsreel.
 9	1936	Special	SPECIAL AWARD	SPECIAL AWARD	an0053916	The Garden of Allah	tt0027657		W. Howard Greene, Harold Rosson	nm0338946,nm0005849	True			To W. Howard Greene and Harold Rosson for the color cinematography of the Selznick International Production, The Garden of Allah.
 9	1936	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class I)	SCIENTIFIC OR TECHNICAL AWARD (Class I)	an0053917				Douglas Shearer, Metro-Goldwyn-Mayer	nm0790428,co0007143	True	Sound		To DOUGLAS SHEARER and the METRO-GOLDWYN-MAYER STUDIO SOUND DEPARTMENT for the development of a practical two-way horn system and a biased Class A push-pull recording system.
@@ -572,21 +572,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 9	1936	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Electrical Research Products Inc.		True	Sound		To ELECTRICAL RESEARCH PRODUCTS, INC. for the ERPI \"Type Q\" portable recording channel.
 9	1936	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Rca Manufacturing Co. Inc.		True	Laboratory		To RCA MANUFACTURING CO., INC., for furnishing a practical design and specifications for a non-slip printer.
 9	1936	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					UNITED ARTISTS STUDIO CORP.		True	Stage Operations		To UNITED ARTISTS STUDIO CORP. for the development of a practical, efficient and quiet wind machine.
-10	1937	Acting	ACTOR	ACTOR	an0047879	Conquest	tt0028739	Charles Boyer	Charles Boyer	nm0000964		Napoleon Bonaparte
-10	1937	Acting	ACTOR	ACTOR	an0047880	A Star Is Born	tt0029606	Fredric March	Fredric March	nm0545298		Norman Maine (Alfred Hinkel)
-10	1937	Acting	ACTOR	ACTOR	an0047881	Night Must Fall	tt0029310	Robert Montgomery	Robert Montgomery	nm0599910		Danny
-10	1937	Acting	ACTOR	ACTOR	an0047882	The Life of Emile Zola	tt0029146	Paul Muni	Paul Muni	nm0612847		Emile Zola
-10	1937	Acting	ACTOR	ACTOR	an0047878	Captains Courageous	tt0028691	Spencer Tracy	Spencer Tracy	nm0000075	True	Manuel
+10	1937	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047879	Conquest	tt0028739	Charles Boyer	Charles Boyer	nm0000964		Napoleon Bonaparte
+10	1937	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047880	A Star Is Born	tt0029606	Fredric March	Fredric March	nm0545298		Norman Maine (Alfred Hinkel)
+10	1937	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047881	Night Must Fall	tt0029310	Robert Montgomery	Robert Montgomery	nm0599910		Danny
+10	1937	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047882	The Life of Emile Zola	tt0029146	Paul Muni	Paul Muni	nm0612847		Emile Zola
+10	1937	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047878	Captains Courageous	tt0028691	Spencer Tracy	Spencer Tracy	nm0000075	True	Manuel
 10	1937	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047889	The Awful Truth	tt0028597	Ralph Bellamy	Ralph Bellamy	nm0000897		Daniel Leeson
 10	1937	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047890	The Hurricane	tt0029030	Thomas Mitchell	Thomas Mitchell	nm0593775		Doctor Kersaint
 10	1937	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047888	The Life of Emile Zola	tt0029146	Joseph Schildkraut	Joseph Schildkraut	nm0771584	True	Captain Alfred Dreyfus
 10	1937	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047891	Lost Horizon	tt0029162	H. B. Warner	H. B. Warner	nm0912478		Chang
 10	1937	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047892	Topper	tt0029682	Roland Young	Roland Young	nm0950019		Cosmo Topper
-10	1937	Acting	ACTRESS	ACTRESS	an0047884	The Awful Truth	tt0028597	Irene Dunne	Irene Dunne	nm0002050		Lucy Warriner
-10	1937	Acting	ACTRESS	ACTRESS	an0047885	Camille	tt0028683	Greta Garbo	Greta Garbo	nm0001256		Marguerite Gautier (Camille)
-10	1937	Acting	ACTRESS	ACTRESS	an0047886	A Star Is Born	tt0029606	Janet Gaynor	Janet Gaynor	nm0310980		Esther Blodgett/Vicki Lester
-10	1937	Acting	ACTRESS	ACTRESS	an0047883	The Good Earth	tt0028944	Luise Rainer	Luise Rainer	nm0707023	True	O-Lan
-10	1937	Acting	ACTRESS	ACTRESS	an0047887	Stella Dallas	tt0029608	Barbara Stanwyck	Barbara Stanwyck	nm0001766		Stella Dallas
+10	1937	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047884	The Awful Truth	tt0028597	Irene Dunne	Irene Dunne	nm0002050		Lucy Warriner
+10	1937	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047885	Camille	tt0028683	Greta Garbo	Greta Garbo	nm0001256		Marguerite Gautier (Camille)
+10	1937	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047886	A Star Is Born	tt0029606	Janet Gaynor	Janet Gaynor	nm0310980		Esther Blodgett/Vicki Lester
+10	1937	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047883	The Good Earth	tt0028944	Luise Rainer	Luise Rainer	nm0707023	True	O-Lan
+10	1937	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047887	Stella Dallas	tt0029608	Barbara Stanwyck	Barbara Stanwyck	nm0001766		Stella Dallas
 10	1937	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047893	In Old Chicago	tt0029047	Alice Brady	Alice Brady	nm0103567	True	Molly O'Leary
 10	1937	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047894	Stage Door	tt0029604	Andrea Leeds	Andrea Leeds	nm0498571		Kaye Hamilton
 10	1937	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047895	Stella Dallas	tt0029608	Anne Shirley	Anne Shirley	nm0794297		Laurel Dallas
@@ -629,20 +629,20 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 10	1937	Production	FILM EDITING	FILM EDITING	an0047941	The Good Earth	tt0028944	Basil Wrangell	Basil Wrangell	nm0942007
 10	1937	Production	FILM EDITING	FILM EDITING	an0047938	Lost Horizon	tt0029162	Gene Havlick, Gene Milford	Gene Havlick, Gene Milford	nm0369879,nm0587332	True
 10	1937	Production	FILM EDITING	FILM EDITING	an0047942	One Hundred Men and a Girl	tt0029347	Bernard W. Burton	Bernard W. Burton	nm0123521
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047961	The Hurricane	tt0029030	Samuel Goldwyn Studio Music Department, Alfred Newman, head of department (Score by Alfred Newman)	Samuel Goldwyn, Alfred Newman	co0058013,nm0000055
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047962	In Old Chicago	tt0029047	20th Century-Fox Studio Music Department, Louis Silvers, head of department (no composer credit)	20th Century-Fox, Louis Silvers	co0028775,nm0799007
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047963	The Life of Emile Zola	tt0029146	Warner Bros. Studio Music Department, Leo Forbstein, head of department (Score by Max Steiner)	Warner Bros., Leo Forbstein, Max Steiner	co0080422,nm0006079,nm0000070
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047964	Lost Horizon	tt0029162	Columbia Studio Music Department, Morris Stoloff, head of department (Score by Dimitri Tiomkin)	Columbia, Morris Stoloff, Dimitri Tiomkin	co0050868,nm0006304,nm0006323
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047965	Make a Wish	tt0029193	Principal Productions, Dr. Hugo Riesenfeld, musical director (Score by Dr. Hugo Riesenfeld)	Principal Productions, Dr. Hugo Riesenfeld	co0030758,nm0006252
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047966	Maytime	tt0029222	Metro-Goldwyn-Mayer Studio Music Department, Nat W. Finston, head of department (Score by Herbert Stothart)	Metro-Goldwyn-Mayer, Nat W. Finston, Herbert Stothart	co0007143,nm0278358,nm0006307
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047960	One Hundred Men and a Girl	tt0029347	Universal Studio Music Department, Charles Previn, head of department (no composer credit)	Universal, Charles Previn	co0005073,nm0006239	True
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047967	Portia on Trial	tt0029433	Republic Studio Music Department, Alberto Colombo, head of department (Score by Alberto Colombo)	Republic, Alberto Colombo	co0020540,nm0173027
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047968	The Prisoner of Zenda	tt0029442	Selznick International Pictures Music Department, Alfred Newman, musical director (Score by Alfred Newman)	Selznick International Pictures, Alfred Newman	co0130901,nm0000055
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047969	Quality Street	tt0029454	RKO Radio Studio Music Department, Roy Webb, musical director (Score by Roy Webb)	RKO Radio, Roy Webb	co0041421,nm0002202
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0400949	Snow White and the Seven Dwarfs	tt0029583	Walt Disney Studio Music Department, Leigh Harline, head of department (Score by Frank Churchill, Leigh Harline and Paul J. Smith)	Walt Disney Studios, Leigh Harline, Frank Churchill, Paul J. Smith	co0008970,nm0363316,nm0161430,nm1345229
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047971	Something to Sing About	tt0029588	Grand National Studio Music Department, C. Bakaleinikoff, musical director (Score by Victor Schertzinger)	Grand National, C. Bakaleinikoff, Victor Schertzinger	?,nm0005954,nm0006276
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047972	Souls at Sea	tt0029593	Paramount Studio Music Department, Boris Morros, head of department (Score by W. Franke Harling and Milan Roder)	Paramount, Boris Morros, W. Franke Harling, Milan Roder	co0023400,nm0607448,nm0006123,nm0006255
-10	1937	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047973	Way Out West	tt0029747	Hal Roach Studio Music Department, Marvin Hatley, head of department (Score by Marvin Hatley)	Hal Roach, Marvin Hatley	co0075561,nm0368943
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047961	The Hurricane	tt0029030	Samuel Goldwyn Studio Music Department, Alfred Newman, head of department (Score by Alfred Newman)	Samuel Goldwyn, Alfred Newman	co0058013,nm0000055
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047962	In Old Chicago	tt0029047	20th Century-Fox Studio Music Department, Louis Silvers, head of department (no composer credit)	20th Century-Fox, Louis Silvers	co0028775,nm0799007
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047963	The Life of Emile Zola	tt0029146	Warner Bros. Studio Music Department, Leo Forbstein, head of department (Score by Max Steiner)	Warner Bros., Leo Forbstein, Max Steiner	co0080422,nm0006079,nm0000070
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047964	Lost Horizon	tt0029162	Columbia Studio Music Department, Morris Stoloff, head of department (Score by Dimitri Tiomkin)	Columbia, Morris Stoloff, Dimitri Tiomkin	co0050868,nm0006304,nm0006323
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047965	Make a Wish	tt0029193	Principal Productions, Dr. Hugo Riesenfeld, musical director (Score by Dr. Hugo Riesenfeld)	Principal Productions, Dr. Hugo Riesenfeld	co0030758,nm0006252
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047966	Maytime	tt0029222	Metro-Goldwyn-Mayer Studio Music Department, Nat W. Finston, head of department (Score by Herbert Stothart)	Metro-Goldwyn-Mayer, Nat W. Finston, Herbert Stothart	co0007143,nm0278358,nm0006307
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047960	One Hundred Men and a Girl	tt0029347	Universal Studio Music Department, Charles Previn, head of department (no composer credit)	Universal, Charles Previn	co0005073,nm0006239	True
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047967	Portia on Trial	tt0029433	Republic Studio Music Department, Alberto Colombo, head of department (Score by Alberto Colombo)	Republic, Alberto Colombo	co0020540,nm0173027
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047968	The Prisoner of Zenda	tt0029442	Selznick International Pictures Music Department, Alfred Newman, musical director (Score by Alfred Newman)	Selznick International Pictures, Alfred Newman	co0130901,nm0000055
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047969	Quality Street	tt0029454	RKO Radio Studio Music Department, Roy Webb, musical director (Score by Roy Webb)	RKO Radio, Roy Webb	co0041421,nm0002202
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0400949	Snow White and the Seven Dwarfs	tt0029583	Walt Disney Studio Music Department, Leigh Harline, head of department (Score by Frank Churchill, Leigh Harline and Paul J. Smith)	Walt Disney Studios, Leigh Harline, Frank Churchill, Paul J. Smith	co0008970,nm0363316,nm0161430,nm1345229
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047971	Something to Sing About	tt0029588	Grand National Studio Music Department, C. Bakaleinikoff, musical director (Score by Victor Schertzinger)	Grand National, C. Bakaleinikoff, Victor Schertzinger	?,nm0005954,nm0006276
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047972	Souls at Sea	tt0029593	Paramount Studio Music Department, Boris Morros, head of department (Score by W. Franke Harling and Milan Roder)	Paramount, Boris Morros, W. Franke Harling, Milan Roder	co0023400,nm0607448,nm0006123,nm0006255
+10	1937	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047973	Way Out West	tt0029747	Hal Roach Studio Music Department, Marvin Hatley, head of department (Score by Marvin Hatley)	Hal Roach, Marvin Hatley	co0075561,nm0368943
 10	1937	Music	MUSIC (Original Song)	MUSIC (Song)	an0047956	Mr. Dodd Takes the Air	tt0029267	Music by Harry Warren; Lyrics by Al Dubin	Harry Warren, Al Dubin	nm0912851,nm0006048		Remember Me
 10	1937	Music	MUSIC (Original Song)	MUSIC (Song)	an0047955	Waikiki Wedding	tt0029742	Music and Lyrics by Harry Owens	Harry Owens	nm0654374	True	Sweet Leilani
 10	1937	Music	MUSIC (Original Song)	MUSIC (Song)	an0047957	Walter Wanger's Vogues of 1938	tt0029737	Music by Sammy Fain; Lyrics by Lew Brown	Sammy Fain, Lew Brown	nm0006066,nm0114095		That Old Feeling
@@ -685,11 +685,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 10	1937	Writing	WRITING (Original Story)	WRITING (Original Story)	an0047906	The Life of Emile Zola	tt0029146	Heinz Herald, Geza Herczeg	Heinz Herald, Geza Herczeg	nm0378431,nm0378773
 10	1937	Writing	WRITING (Original Story)	WRITING (Original Story)	an0047907	One Hundred Men and a Girl	tt0029347	Hans Kraly	Hans Kraly	nm0473134
 10	1937	Writing	WRITING (Original Story)	WRITING (Original Story)	an0047903	A Star Is Born	tt0029606	William A. Wellman, Robert Carson	William A. Wellman, Robert Carson	nm0920074,nm0308604	True
-10	1937	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047909	The Awful Truth	tt0028597	Vina Delmar	Vina Delmar	nm0217568
-10	1937	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047910	Captains Courageous	tt0028691	John Lee Mahin, Marc Connelly, Dale Van Every	John Lee Mahin, Marc Connelly, Dale Van Every	nm0536941,nm0175091,nm0886861
-10	1937	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047908	The Life of Emile Zola	tt0029146	Norman Reilly Raine, Heinz Herald, Geza Herczeg	Norman Reilly Raine, Heinz Herald, Geza Herczeg	nm0706993,nm0378431,nm0378773	True
-10	1937	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047911	Stage Door	tt0029604	Morris Ryskind, Anthony Veiller	Morris Ryskind, Anthony Veiller	nm0753452,nm0892044
-10	1937	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047912	A Star Is Born	tt0029606	Dorothy Parker, Alan Campbell, Robert Carson	Dorothy Parker, Alan Campbell, Robert Carson	nm0662213,nm0132180,nm0308604
+10	1937	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047909	The Awful Truth	tt0028597	Vina Delmar	Vina Delmar	nm0217568
+10	1937	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047910	Captains Courageous	tt0028691	John Lee Mahin, Marc Connelly, Dale Van Every	John Lee Mahin, Marc Connelly, Dale Van Every	nm0536941,nm0175091,nm0886861
+10	1937	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047908	The Life of Emile Zola	tt0029146	Norman Reilly Raine, Heinz Herald, Geza Herczeg	Norman Reilly Raine, Heinz Herald, Geza Herczeg	nm0706993,nm0378431,nm0378773	True
+10	1937	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047911	Stage Door	tt0029604	Morris Ryskind, Anthony Veiller	Morris Ryskind, Anthony Veiller	nm0753452,nm0892044
+10	1937	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047912	A Star Is Born	tt0029606	Dorothy Parker, Alan Campbell, Robert Carson	Dorothy Parker, Alan Campbell, Robert Carson	nm0662213,nm0132180,nm0308604
 10	1937	Special	SPECIAL AWARD	SPECIAL AWARD	an0048512				Mack Sennett	nm0784407	True			To Mack Sennett, \"for his lasting contribution to the comedy technique of the screen, the basic principles of which are as important today as when they were first put into practice, the Academy presents a Special Award to that master of fun, discoverer of stars, sympathetic, kindly, understanding comedy genius - Mack Sennett.\"
 10	1937	Special	SPECIAL AWARD	SPECIAL AWARD	an0048513				Edgar Bergen	nm0001944	True			To Edgar Bergen for his outstanding comedy creation, \"Charlie McCarthy.\"
 10	1937	Special	SPECIAL AWARD	SPECIAL AWARD	anxxx001				The Museum of Modern Art Film Library	co0089684	True			To The Museum of Modern Art Film Library for its significant work in collecting films dating from 1895 to the present and for the first time making available to the public the means of studying the historical and aesthetic development of the motion picture as one of the major arts.
@@ -706,21 +706,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 10	1937	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Rca Manufacturing Co. Inc.		True	Laboratory		To RCA MANUFACTURING CO., INC. for the introduction of the modulated high-frequency method of determining optimum photographic processing conditions for variable width sound tracks.
 10	1937	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					JOSEPH E. ROBBINS, PARAMOUNT PICTURES		True	Stage Operations		To JOSEPH E. ROBBINS and PARAMOUNT PICTURES, INC. for an exceptional application of acoustic principles to the sound proofing of gasoline generators and water pumps.
 10	1937	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0048527				Douglas Shearer, Metro-Goldwyn-Mayer	nm0790428,co0007143	True	Sound		To DOUGLAS SHEARER and the METRO-GOLDWYN-MAYER STUDIO SOUND DEPARTMENT for the design of the film drive mechanism as incorporated in the ERPI 1010 reproducer.
-11	1938	Acting	ACTOR	ACTOR	an0049847	Algiers	tt0029855	Charles Boyer	Charles Boyer	nm0000964		Pepe Le Moko
-11	1938	Acting	ACTOR	ACTOR	an0049848	Angels with Dirty Faces	tt0029870	James Cagney	James Cagney	nm0000010		Rocky Sullivan
-11	1938	Acting	ACTOR	ACTOR	an0049849	The Citadel	tt0029995	Robert Donat	Robert Donat	nm0232196		Andrew Mason
-11	1938	Acting	ACTOR	ACTOR	an0049850	Pygmalion	tt0030637	Leslie Howard	Leslie Howard	nm0001366		Professor Henry Higgins
-11	1938	Acting	ACTOR	ACTOR	an0049846	Boys Town	tt0029942	Spencer Tracy	Spencer Tracy	nm0000075	True	Father Flanagan
+11	1938	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049847	Algiers	tt0029855	Charles Boyer	Charles Boyer	nm0000964		Pepe Le Moko
+11	1938	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049848	Angels with Dirty Faces	tt0029870	James Cagney	James Cagney	nm0000010		Rocky Sullivan
+11	1938	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049849	The Citadel	tt0029995	Robert Donat	Robert Donat	nm0232196		Andrew Mason
+11	1938	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049850	Pygmalion	tt0030637	Leslie Howard	Leslie Howard	nm0001366		Professor Henry Higgins
+11	1938	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049846	Boys Town	tt0029942	Spencer Tracy	Spencer Tracy	nm0000075	True	Father Flanagan
 11	1938	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049856	Kentucky	tt0030317	Walter Brennan	Walter Brennan	nm0000974	True	Peter Goodwin
 11	1938	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049857	Four Daughters	tt0030149	John Garfield	John Garfield	nm0002092		Mickey Borden
 11	1938	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049858	Algiers	tt0029855	Gene Lockhart	Gene Lockhart	nm0516876		Regis
 11	1938	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049859	Marie Antoinette	tt0030418	Robert Morley	Robert Morley	nm0605923		King Louis XVI
 11	1938	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049860	If I Were King	tt0030265	Basil Rathbone	Basil Rathbone	nm0001651		Louis XI
-11	1938	Acting	ACTRESS	ACTRESS	an0049852	White Banners	tt0030973	Fay Bainter	Fay Bainter	nm0047810		Hannah
-11	1938	Acting	ACTRESS	ACTRESS	an0049851	Jezebel	tt0030287	Bette Davis	Bette Davis	nm0000012	True	Julie Morrison
-11	1938	Acting	ACTRESS	ACTRESS	an0049853	Pygmalion	tt0030637	Wendy Hiller	Wendy Hiller	nm0384908		Eliza Doolittle
-11	1938	Acting	ACTRESS	ACTRESS	an0049854	Marie Antoinette	tt0030418	Norma Shearer	Norma Shearer	nm0790454		Marie Antoinette
-11	1938	Acting	ACTRESS	ACTRESS	an0049855	Three Comrades	tt0030865	Margaret Sullavan	Margaret Sullavan	nm0837925		Pat Hollmann
+11	1938	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049852	White Banners	tt0030973	Fay Bainter	Fay Bainter	nm0047810		Hannah
+11	1938	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049851	Jezebel	tt0030287	Bette Davis	Bette Davis	nm0000012	True	Julie Morrison
+11	1938	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049853	Pygmalion	tt0030637	Wendy Hiller	Wendy Hiller	nm0384908		Eliza Doolittle
+11	1938	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049854	Marie Antoinette	tt0030418	Norma Shearer	Norma Shearer	nm0790454		Marie Antoinette
+11	1938	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049855	Three Comrades	tt0030865	Margaret Sullavan	Margaret Sullavan	nm0837925		Pat Hollmann
 11	1938	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049861	Jezebel	tt0030287	Fay Bainter	Fay Bainter	nm0047810	True	Aunt Belle Massey
 11	1938	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049862	Of Human Hearts	tt0030517	Beulah Bondi	Beulah Bondi	nm0094135		Mary Wilkins
 11	1938	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049863	Merrily We Live	tt0030442	Billie Burke	Billie Burke	nm0000992		Mrs. Emily Kilbourne
@@ -769,17 +769,17 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 11	1938	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0049948	Pacific Liner	tt0031774	Russell Bennett	Russell Bennett	nm0072021
 11	1938	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0049949	Suez	tt0030811	Louis Silvers	Louis Silvers	nm0799007
 11	1938	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0049950	The Young in Heart	tt0031002	Franz Waxman	Franz Waxman	nm0000077
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049929	Alexander's Ragtime Band	tt0029852	Alfred Newman	Alfred Newman	nm0000055	True
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049930	Carefree	tt0029971	Victor Baravalle	Victor Baravalle	nm0053127
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049931	Girls' School	tt0030184	Morris Stoloff, Gregory Stone	Morris Stoloff, Gregory Stone	nm0006304,nm0831899
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049932	The Goldwyn Follies	tt0030194	Alfred Newman	Alfred Newman	nm0000055
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049933	Jezebel	tt0030287	Max Steiner	Max Steiner	nm0000070
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049934	Mad about Music	tt0030395	Charles Previn, Frank Skinner	Charles Previn, Frank Skinner	nm0006239,nm0804244
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049935	Storm over Bengal	tt0030798	Cy Feuer	Cy Feuer	nm0006074
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049936	Sweethearts	tt0030817	Herbert Stothart	Herbert Stothart	nm0006307
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049937	There Goes My Heart	tt0030856	Marvin Hatley	Marvin Hatley	nm0368943
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049938	Tropic Holiday	tt0030897	Boris Morros	Boris Morros	nm0607448
-11	1938	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0049939	The Young in Heart	tt0031002	Franz Waxman	Franz Waxman	nm0000077
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049929	Alexander's Ragtime Band	tt0029852	Alfred Newman	Alfred Newman	nm0000055	True
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049930	Carefree	tt0029971	Victor Baravalle	Victor Baravalle	nm0053127
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049931	Girls' School	tt0030184	Morris Stoloff, Gregory Stone	Morris Stoloff, Gregory Stone	nm0006304,nm0831899
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049932	The Goldwyn Follies	tt0030194	Alfred Newman	Alfred Newman	nm0000055
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049933	Jezebel	tt0030287	Max Steiner	Max Steiner	nm0000070
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049934	Mad about Music	tt0030395	Charles Previn, Frank Skinner	Charles Previn, Frank Skinner	nm0006239,nm0804244
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049935	Storm over Bengal	tt0030798	Cy Feuer	Cy Feuer	nm0006074
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049936	Sweethearts	tt0030817	Herbert Stothart	Herbert Stothart	nm0006307
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049937	There Goes My Heart	tt0030856	Marvin Hatley	Marvin Hatley	nm0368943
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049938	Tropic Holiday	tt0030897	Boris Morros	Boris Morros	nm0607448
+11	1938	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0049939	The Young in Heart	tt0031002	Franz Waxman	Franz Waxman	nm0000077
 11	1938	Music	MUSIC (Original Song)	MUSIC (Song)	an0049920	Mannequin	tt0030413	Music by Edward Ward; Lyrics by Chet Forrest and Bob Wright	Edward Ward, Chet Forrest, Bob Wright	nm0911518,nm0286609,nm0942243		Always And Always
 11	1938	Music	MUSIC (Original Song)	MUSIC (Song)	an0049921	Carefree	tt0029971	Music and Lyrics by Irving Berlin	Irving Berlin	nm0000927		Change Partners
 11	1938	Music	MUSIC (Original Song)	MUSIC (Song)	an0049922	The Cowboy and the Lady	tt0030018	Music by Lionel Newman; Lyrics by Arthur Quenzer	Lionel Newman, Arthur Quenzer	nm0006213,nm0703242		The Cowboy And The Lady
@@ -827,11 +827,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 11	1938	Writing	WRITING (Original Story)	WRITING (Original Story)	an0049871	Boys Town	tt0029942	Dore Schary, Eleanore Griffin	Dore Schary, Eleanore Griffin	nm0770196,nm0341178	True
 11	1938	Writing	WRITING (Original Story)	WRITING (Original Story)	an0049875	Mad about Music	tt0030395	Marcella Burke, Frederick Kohner	Marcella Burke, Frederick Kohner	nm0121781,nm0463430
 11	1938	Writing	WRITING (Original Story)	WRITING (Original Story)	an0049876	Test Pilot	tt0030848	Frank Wead	Frank Wead	nm0915693
-11	1938	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049878	Boys Town	tt0029942	John Meehan, Dore Schary	John Meehan, Dore Schary	nm0576046,nm0770196
-11	1938	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049879	The Citadel	tt0029995	Ian Dalrymple, Frank Wead, Elizabeth Hill	Ian Dalrymple, Frank Wead, Elizabeth Hill	nm0198202,nm0915693,nm0384227
-11	1938	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049880	Four Daughters	tt0030149	Julius J. Epstein, Lenore Coffee	Julius J. Epstein, Lenore Coffee	nm0258493,nm0168829
-11	1938	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049877	Pygmalion	tt0030637	Screenplay and Dialogue by George Bernard Shaw; Adaptation by W. P. Lipscomb, Cecil Lewis, Ian Dalrymple	George Bernard Shaw, W. P. Lipscomb, Cecil Lewis, Ian Dalrymple	nm0789737,nm0513744,nm0507021,nm0198202	True
-11	1938	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049881	You Can't Take It with You	tt0030993	Robert Riskin	Robert Riskin	nm0728307
+11	1938	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049878	Boys Town	tt0029942	John Meehan, Dore Schary	John Meehan, Dore Schary	nm0576046,nm0770196
+11	1938	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049879	The Citadel	tt0029995	Ian Dalrymple, Frank Wead, Elizabeth Hill	Ian Dalrymple, Frank Wead, Elizabeth Hill	nm0198202,nm0915693,nm0384227
+11	1938	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049880	Four Daughters	tt0030149	Julius J. Epstein, Lenore Coffee	Julius J. Epstein, Lenore Coffee	nm0258493,nm0168829
+11	1938	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049877	Pygmalion	tt0030637	Screenplay and Dialogue by George Bernard Shaw; Adaptation by W. P. Lipscomb, Cecil Lewis, Ian Dalrymple	George Bernard Shaw, W. P. Lipscomb, Cecil Lewis, Ian Dalrymple	nm0789737,nm0513744,nm0507021,nm0198202	True
+11	1938	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049881	You Can't Take It with You	tt0030993	Robert Riskin	Robert Riskin	nm0728307
 11	1938	Special	SPECIAL AWARD	SPECIAL AWARD	an0053621				Deanna Durbin, Mickey Rooney	nm0002052,nm0001682	True			To Deanna Durbin and Mickey Rooney for their significant contribution in bringing to the screen the spirit and personification of youth, and as juvenile players setting a high standard of ability and achievement.
 11	1938	Special	SPECIAL AWARD	SPECIAL AWARD	an0053622				Harry M. Warner	nm0912481	True			To Harry M. Warner in recognition of patriotic service in the production of historical short subjects presenting significant episodes in the early struggle of the American people for liberty.
 11	1938	Special	SPECIAL AWARD	SPECIAL AWARD	an0053623	Snow White and the Seven Dwarfs	tt0029583		Walt Disney	nm0000370	True			To Walt Disney for Snow White and the Seven Dwarfs, recognized as a significant screen innovation which has charmed millions and pioneered a great new entertainment field for the motion picture cartoon.
@@ -847,21 +847,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 11	1938	Special	IRVING G. THALBERG MEMORIAL AWARD	IRVING G. THALBERG MEMORIAL AWARD	an0053628			Darryl F. Zanuck	Darryl F. Zanuck	nm0953123			NOTE: Did not win the award. This is the only year that nominations were announced for the Thalberg award.
 11	1938	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0053636				John Aalberg, Rko Radio	nm0007356,co0041421	True	Sound		To JOHN AALBERG and the RKO RADIO STUDIO SOUND DEPARTMENT for the application of compression to variable area recording in motion picture production.
 11	1938	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0053637				Byron Haskin, Warner Bros. Studio	nm0005738,co0080422	True	Special Photographic		To BYRON HASKIN and the SPECIAL EFFECTS DEPARTMENT OF WARNER BROS. STUDIO for pioneering the development and for the first practical application to motion picture production of the triple head background projector.
-12	1939	Acting	ACTOR	ACTOR	an0047442	Goodbye, Mr. Chips	tt0031385	Robert Donat	Robert Donat	nm0232196	True	Mr. Chips
-12	1939	Acting	ACTOR	ACTOR	an0047443	Gone with the Wind	tt0031381	Clark Gable	Clark Gable	nm0000022		Rhett Butler
-12	1939	Acting	ACTOR	ACTOR	an0047444	Wuthering Heights	tt0032145	Laurence Olivier	Laurence Olivier	nm0000059		Heathcliff
-12	1939	Acting	ACTOR	ACTOR	an0047445	Babes in Arms	tt0031066	Mickey Rooney	Mickey Rooney	nm0001682		Mickey Moran
-12	1939	Acting	ACTOR	ACTOR	an0047446	Mr. Smith Goes to Washington	tt0031679	James Stewart	James Stewart	nm0000071		Jefferson Smith
+12	1939	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047442	Goodbye, Mr. Chips	tt0031385	Robert Donat	Robert Donat	nm0232196	True	Mr. Chips
+12	1939	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047443	Gone with the Wind	tt0031381	Clark Gable	Clark Gable	nm0000022		Rhett Butler
+12	1939	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047444	Wuthering Heights	tt0032145	Laurence Olivier	Laurence Olivier	nm0000059		Heathcliff
+12	1939	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047445	Babes in Arms	tt0031066	Mickey Rooney	Mickey Rooney	nm0001682		Mickey Moran
+12	1939	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047446	Mr. Smith Goes to Washington	tt0031679	James Stewart	James Stewart	nm0000071		Jefferson Smith
 12	1939	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047453	Juarez	tt0031516	Brian Aherne	Brian Aherne	nm0000731		Emperor Maximilian von Habsburg
 12	1939	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047454	Mr. Smith Goes to Washington	tt0031679	Harry Carey	Harry Carey	nm0002503		President of the Senate
 12	1939	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047455	Beau Geste	tt0031088	Brian Donlevy	Brian Donlevy	nm0002046		Sergeant Markoff
 12	1939	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047452	Stagecoach	tt0031971	Thomas Mitchell	Thomas Mitchell	nm0593775	True	Dr. Josiah Boone
 12	1939	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047456	Mr. Smith Goes to Washington	tt0031679	Claude Rains	Claude Rains	nm0001647		Senator Joseph Paine
-12	1939	Acting	ACTRESS	ACTRESS	an0047448	Dark Victory	tt0031210	Bette Davis	Bette Davis	nm0000012		Judith Traherne
-12	1939	Acting	ACTRESS	ACTRESS	an0047449	Love Affair	tt0031593	Irene Dunne	Irene Dunne	nm0002050		Terry McKay
-12	1939	Acting	ACTRESS	ACTRESS	an0047450	Ninotchka	tt0031725	Greta Garbo	Greta Garbo	nm0001256		Lena Yakushova (Ninotchka)
-12	1939	Acting	ACTRESS	ACTRESS	an0047451	Goodbye, Mr. Chips	tt0031385	Greer Garson	Greer Garson	nm0002093		Katherine Chipping
-12	1939	Acting	ACTRESS	ACTRESS	an0047447	Gone with the Wind	tt0031381	Vivien Leigh	Vivien Leigh	nm0000046	True	Scarlett O'Hara
+12	1939	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047448	Dark Victory	tt0031210	Bette Davis	Bette Davis	nm0000012		Judith Traherne
+12	1939	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047449	Love Affair	tt0031593	Irene Dunne	Irene Dunne	nm0002050		Terry McKay
+12	1939	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047450	Ninotchka	tt0031725	Greta Garbo	Greta Garbo	nm0001256		Lena Yakushova (Ninotchka)
+12	1939	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047451	Goodbye, Mr. Chips	tt0031385	Greer Garson	Greer Garson	nm0002093		Katherine Chipping
+12	1939	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047447	Gone with the Wind	tt0031381	Vivien Leigh	Vivien Leigh	nm0000046	True	Scarlett O'Hara
 12	1939	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047458	Gone with the Wind	tt0031381	Olivia de Havilland	Olivia de Havilland	nm0000014		Melanie Hamilton
 12	1939	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047459	Wuthering Heights	tt0032145	Geraldine Fitzgerald	Geraldine Fitzgerald	nm0280242		Isabella
 12	1939	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047457	Gone with the Wind	tt0031381	Hattie McDaniel	Hattie McDaniel	nm0567408	True	Mammy
@@ -918,19 +918,19 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 12	1939	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0047555	The Rains Came	tt0031835	Alfred Newman	Alfred Newman	nm0000055
 12	1939	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0047545	The Wizard of Oz	tt0032138	Herbert Stothart	Herbert Stothart	nm0006307	True
 12	1939	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0047556	Wuthering Heights	tt0032145	Alfred Newman	Alfred Newman	nm0000055
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047533	Babes in Arms	tt0031066	George E. Stoll, Roger Edens	George E. Stoll, Roger Edens	nm0006303,nm0249136
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047534	First Love	tt0031311	Charles Previn	Charles Previn	nm0006239
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047535	The Great Victor Herbert	tt0031393	Phil Boutelje, Arthur Lange	Phil Boutelje, Arthur Lange	nm0100287,nm0486075
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047536	The Hunchback of Notre Dame	tt0031455	Alfred Newman	Alfred Newman	nm0000055
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047537	Intermezzo	tt0031491	Lou Forbes	Lou Forbes	nm0006078
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047538	Mr. Smith Goes to Washington	tt0031679	Dimitri Tiomkin	Dimitri Tiomkin	nm0006323
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047539	Of Mice and Men	tt0031742	Aaron Copland	Aaron Copland	nm0178716
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047540	The Private Lives of Elizabeth and Essex	tt0031826	Erich Wolfgang Korngold	Erich Wolfgang Korngold	nm0006157
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047541	She Married a Cop	tt0031921	Cy Feuer	Cy Feuer	nm0006074
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047532	Stagecoach	tt0031971	Richard Hageman, Frank Harling, John Leipold, Leo Shuken	Richard Hageman, Frank Harling, John Leipold, Leo Shuken	nm0006119,nm0006123,nm0500506,nm0795640	True
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047542	Swanee River	tt0031996	Louis Silvers	Louis Silvers	nm0799007
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047543	They Shall Have Music	tt0032023	Alfred Newman	Alfred Newman	nm0000055
-12	1939	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0047544	Way Down South	tt0032114	Victor Young	Victor Young	nm0000082
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047533	Babes in Arms	tt0031066	George E. Stoll, Roger Edens	George E. Stoll, Roger Edens	nm0006303,nm0249136
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047534	First Love	tt0031311	Charles Previn	Charles Previn	nm0006239
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047535	The Great Victor Herbert	tt0031393	Phil Boutelje, Arthur Lange	Phil Boutelje, Arthur Lange	nm0100287,nm0486075
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047536	The Hunchback of Notre Dame	tt0031455	Alfred Newman	Alfred Newman	nm0000055
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047537	Intermezzo	tt0031491	Lou Forbes	Lou Forbes	nm0006078
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047538	Mr. Smith Goes to Washington	tt0031679	Dimitri Tiomkin	Dimitri Tiomkin	nm0006323
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047539	Of Mice and Men	tt0031742	Aaron Copland	Aaron Copland	nm0178716
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047540	The Private Lives of Elizabeth and Essex	tt0031826	Erich Wolfgang Korngold	Erich Wolfgang Korngold	nm0006157
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047541	She Married a Cop	tt0031921	Cy Feuer	Cy Feuer	nm0006074
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047532	Stagecoach	tt0031971	Richard Hageman, Frank Harling, John Leipold, Leo Shuken	Richard Hageman, Frank Harling, John Leipold, Leo Shuken	nm0006119,nm0006123,nm0500506,nm0795640	True
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047542	Swanee River	tt0031996	Louis Silvers	Louis Silvers	nm0799007
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047543	They Shall Have Music	tt0032023	Alfred Newman	Alfred Newman	nm0000055
+12	1939	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0047544	Way Down South	tt0032114	Victor Young	Victor Young	nm0000082
 12	1939	Music	MUSIC (Original Song)	MUSIC (Song)	an0047529	Gulliver's Travels	tt0031397	Music by Ralph Rainger; Lyrics by Leo Robin	Ralph Rainger, Leo Robin	nm0006247,nm0732209		Faithful Forever
 12	1939	Music	MUSIC (Original Song)	MUSIC (Song)	an0047530	Second Fiddle	tt0031907	Music and Lyrics by Irving Berlin	Irving Berlin	nm0000927		I Poured My Heart Into A Song
 12	1939	Music	MUSIC (Original Song)	MUSIC (Song)	an0047528	The Wizard of Oz	tt0032138	Music by Harold Arlen; Lyrics by E. Y. Harburg	Harold Arlen, E. Y. Harburg	nm0002182,nm0361971	True	Over The Rainbow
@@ -979,11 +979,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 12	1939	Writing	WRITING (Original Story)	WRITING (Original Story)	an0047467	Mr. Smith Goes to Washington	tt0031679	Lewis R. Foster	Lewis R. Foster	nm0287931	True
 12	1939	Writing	WRITING (Original Story)	WRITING (Original Story)	an0047470	Ninotchka	tt0031725	Melchior Lengyel	Melchior Lengyel	nm0501872
 12	1939	Writing	WRITING (Original Story)	WRITING (Original Story)	an0047471	Young Mr. Lincoln	tt0032155	Lamar Trotti	Lamar Trotti	nm0873707
-12	1939	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047472	Gone with the Wind	tt0031381	Sidney Howard	Sidney Howard	nm0397608	True
-12	1939	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047473	Goodbye, Mr. Chips	tt0031385	R. C. Sherriff, Claudine West, Eric Maschwitz	R. C. Sherriff, Claudine West, Eric Maschwitz	nm0792670,nm0921995,nm0556178
-12	1939	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047474	Mr. Smith Goes to Washington	tt0031679	Sidney Buchman	Sidney Buchman	nm0118227
-12	1939	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047475	Ninotchka	tt0031725	Charles Brackett, Billy Wilder, Walter Reisch	Charles Brackett, Billy Wilder, Walter Reisch	nm0102818,nm0000697,nm0281556
-12	1939	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047476	Wuthering Heights	tt0032145	Charles MacArthur, Ben Hecht	Charles MacArthur, Ben Hecht	nm0531269,nm0372942
+12	1939	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047472	Gone with the Wind	tt0031381	Sidney Howard	Sidney Howard	nm0397608	True
+12	1939	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047473	Goodbye, Mr. Chips	tt0031385	R. C. Sherriff, Claudine West, Eric Maschwitz	R. C. Sherriff, Claudine West, Eric Maschwitz	nm0792670,nm0921995,nm0556178
+12	1939	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047474	Mr. Smith Goes to Washington	tt0031679	Sidney Buchman	Sidney Buchman	nm0118227
+12	1939	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047475	Ninotchka	tt0031725	Charles Brackett, Billy Wilder, Walter Reisch	Charles Brackett, Billy Wilder, Walter Reisch	nm0102818,nm0000697,nm0281556
+12	1939	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047476	Wuthering Heights	tt0032145	Charles MacArthur, Ben Hecht	Charles MacArthur, Ben Hecht	nm0531269,nm0372942
 12	1939	Special	SPECIAL AWARD	SPECIAL AWARD	an0055841				Douglas Fairbanks	nm0001196	True			To Douglas Fairbanks (Commemorative Award) - recognizing the unique and outstanding contribution of Douglas Fairbanks, first President of the Academy, to the international development of the motion picture.
 12	1939	Special	SPECIAL AWARD	SPECIAL AWARD	an0055842				The Motion Picture Relief Fund, Jean Hersholt, Ralph Morgan, Ralph Block, Conrad Nagel	?,nm0380965,nm0604960,nm0088759,nm0619261	True			To The Motion Picture Relief Fund - acknowledging the outstanding services to the industry during the past year of the Motion Picture Relief Fund and its progressive leadership. Presented to Jean Hersholt, President; Ralph Morgan, Chairman of the Executive Committee; Ralph Block, First Vice-President; and Conrad Nagel.
 12	1939	Special	SPECIAL AWARD	SPECIAL AWARD	an0055843				Judy Garland	nm0000023	True			To Judy Garland for her outstanding performance as a screen juvenile during the past year.
@@ -998,21 +998,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 12	1939	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					HAROLD NYE		True	Lighting		To HAROLD NYE of Warner Bros. Studio for a miniature incandescent spot lamp.
 12	1939	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					A. J. TONDREAU		True	Laboratory		To A. J. TONDREAU of Warner Bros. Studio for the design and manufacture of an improved sound track printer.
 12	1939	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0055861	Gone with the Wind	tt0031381		F. R. ABBOTT, HALLER BELT, ALAN COOK, the BAUSCH & LOMB OPTICAL COMPANY, The MITCHELL CAMERA COMPANY, MOLE-RICHARDSON COMPANY, CHARLES HANDLEY, DAVID JOY, the NATIONAL CARBON COMPANY, WINTON HOCH, TECHNICOLOR MOTION PICTURE CORP., DON MUSGRAVE, SELZNICK INTERNATIONAL PICTURES INC.	nm1226743,nm1226921,nm1226718,co0051159,?,?,nm1227736,nm1290592,?,nm0005743,?,nm0615662,co0130901	True	Special Photographic		For important contributions in cooperative development of new improved Process Projection Equipment: F. R. ABBOTT, HALLER BELT, ALAN COOK and the BAUSCH & LOMB OPTICAL COMPANY for faster projection lenses; The MITCHELL CAMERA COMPANY for a new type process projection head; MOLE-RICHARDSON COMPANY for a new type automatically controlled projection arc lamp; CHARLES HANDLEY, DAVID JOY and the NATIONAL CARBON COMPANY for improved and more stable high-intensity carbons; WINTON HOCH and the TECHNICOLOR MOTION PICTURE CORP. for an auxiliary optical system; DON MUSGRAVE and SELZNICK INTERNATIONAL PICTURES, INC. for pioneering in the use of coordinated equipment in the production, Gone with the Wind.
-13	1940	Acting	ACTOR	ACTOR	an0052925	The Great Dictator	tt0032553	Charles Chaplin	Charles Chaplin	nm0000122		Hynkel, Dictator of Tomania
-13	1940	Acting	ACTOR	ACTOR	an0052926	The Grapes of Wrath	tt0032551	Henry Fonda	Henry Fonda	nm0000020		Tom Joad
-13	1940	Acting	ACTOR	ACTOR	an0052927	Abe Lincoln in Illinois	tt0032181	Raymond Massey	Raymond Massey	nm0557339		Abraham Lincoln
-13	1940	Acting	ACTOR	ACTOR	an0052928	Rebecca	tt0032976	Laurence Olivier	Laurence Olivier	nm0000059		Maxim de Winter
-13	1940	Acting	ACTOR	ACTOR	an0052924	The Philadelphia Story	tt0032904	James Stewart	James Stewart	nm0000071	True	Mike Connor
+13	1940	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052925	The Great Dictator	tt0032553	Charles Chaplin	Charles Chaplin	nm0000122		Hynkel, Dictator of Tomania
+13	1940	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052926	The Grapes of Wrath	tt0032551	Henry Fonda	Henry Fonda	nm0000020		Tom Joad
+13	1940	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052927	Abe Lincoln in Illinois	tt0032181	Raymond Massey	Raymond Massey	nm0557339		Abraham Lincoln
+13	1940	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052928	Rebecca	tt0032976	Laurence Olivier	Laurence Olivier	nm0000059		Maxim de Winter
+13	1940	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052924	The Philadelphia Story	tt0032904	James Stewart	James Stewart	nm0000071	True	Mike Connor
 13	1940	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052935	Foreign Correspondent	tt0032484	Albert Basserman	Albert Basserman	nm0060168		Van Meer
 13	1940	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052934	The Westerner	tt0033253	Walter Brennan	Walter Brennan	nm0000974	True	Judge Roy Bean
 13	1940	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052936	They Knew What They Wanted	tt0033150	William Gargan	William Gargan	nm0307326		Joe, the Foreman
 13	1940	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052937	The Great Dictator	tt0032553	Jack Oakie	Jack Oakie	nm0642988		Napaloni, Dictator of Bacteria
 13	1940	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052938	The Letter	tt0032701	James Stephenson	James Stephenson	nm0827263		Howard Joyce
-13	1940	Acting	ACTRESS	ACTRESS	an0052930	The Letter	tt0032701	Bette Davis	Bette Davis	nm0000012		Leslie Crosbie
-13	1940	Acting	ACTRESS	ACTRESS	an0052931	Rebecca	tt0032976	Joan Fontaine	Joan Fontaine	nm0000021		Mrs. de Winter
-13	1940	Acting	ACTRESS	ACTRESS	an0052932	The Philadelphia Story	tt0032904	Katharine Hepburn	Katharine Hepburn	nm0000031		Tracy Lord
-13	1940	Acting	ACTRESS	ACTRESS	an0052929	Kitty Foyle	tt0032671	Ginger Rogers	Ginger Rogers	nm0001677	True	Kitty Foyle
-13	1940	Acting	ACTRESS	ACTRESS	an0052933	Our Town	tt0032881	Martha Scott	Martha Scott	nm0779549		Emily Webb
+13	1940	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052930	The Letter	tt0032701	Bette Davis	Bette Davis	nm0000012		Leslie Crosbie
+13	1940	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052931	Rebecca	tt0032976	Joan Fontaine	Joan Fontaine	nm0000021		Mrs. de Winter
+13	1940	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052932	The Philadelphia Story	tt0032904	Katharine Hepburn	Katharine Hepburn	nm0000031		Tracy Lord
+13	1940	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052929	Kitty Foyle	tt0032671	Ginger Rogers	Ginger Rogers	nm0001677	True	Kitty Foyle
+13	1940	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052933	Our Town	tt0032881	Martha Scott	Martha Scott	nm0779549		Emily Webb
 13	1940	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052940	Rebecca	tt0032976	Judith Anderson	Judith Anderson	nm0000752		Mrs. Danvers
 13	1940	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052939	The Grapes of Wrath	tt0032551	Jane Darwell	Jane Darwell	nm0002034	True	Ma Joad
 13	1940	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052941	The Philadelphia Story	tt0032904	Ruth Hussey	Ruth Hussey	nm0404046		Liz Imbrie
@@ -1078,15 +1078,15 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 13	1940	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0053059	Rebecca	tt0032976	Franz Waxman	Franz Waxman	nm0000077
 13	1940	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0053060	The Thief of Bagdad	tt0033152	Miklos Rozsa	Miklos Rozsa	nm0000067
 13	1940	Music	MUSIC (Original Score)	MUSIC (Original Score)	an0053061	Waterloo Bridge	tt0033238	Herbert Stothart	Herbert Stothart	nm0006307
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053037	Arise, My Love	tt0032220	Victor Young	Victor Young	nm0000082
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053038	Hit Parade of 1941	tt0032600	Cy Feuer	Cy Feuer	nm0006074
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053039	Irene	tt0032638	Anthony Collins	Anthony Collins	nm0172141
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053040	Our Town	tt0032881	Aaron Copland	Aaron Copland	nm0178716
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053041	The Sea Hawk	tt0033028	Erich Wolfgang Korngold	Erich Wolfgang Korngold	nm0006157
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053042	Second Chorus	tt0033029	Artie Shaw	Artie Shaw	nm0789600
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053043	Spring Parade	tt0033095	Charles Previn	Charles Previn	nm0006239
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053044	Strike Up the Band	tt0033110	Roger Edens, Georgie Stoll	Roger Edens, Georgie Stoll	nm0249136,nm0006303
-13	1940	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053036	Tin Pan Alley	tt0033167	Alfred Newman	Alfred Newman	nm0000055	True
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053037	Arise, My Love	tt0032220	Victor Young	Victor Young	nm0000082
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053038	Hit Parade of 1941	tt0032600	Cy Feuer	Cy Feuer	nm0006074
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053039	Irene	tt0032638	Anthony Collins	Anthony Collins	nm0172141
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053040	Our Town	tt0032881	Aaron Copland	Aaron Copland	nm0178716
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053041	The Sea Hawk	tt0033028	Erich Wolfgang Korngold	Erich Wolfgang Korngold	nm0006157
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053042	Second Chorus	tt0033029	Artie Shaw	Artie Shaw	nm0789600
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053043	Spring Parade	tt0033095	Charles Previn	Charles Previn	nm0006239
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053044	Strike Up the Band	tt0033110	Roger Edens, Georgie Stoll	Roger Edens, Georgie Stoll	nm0249136,nm0006303
+13	1940	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053036	Tin Pan Alley	tt0033167	Alfred Newman	Alfred Newman	nm0000055	True
 13	1940	Music	MUSIC (Original Song)	MUSIC (Song)	an0053028	Down Argentine Way	tt0032410	Music by Harry Warren; Lyrics by Mack Gordon	Harry Warren, Mack Gordon	nm0912851,nm0330418		Down Argentina Way
 13	1940	Music	MUSIC (Original Song)	MUSIC (Song)	an0053029	You'll Find Out	tt0033283	Music by Jimmy McHugh; Lyrics by Johnny Mercer	Jimmy McHugh, Johnny Mercer	nm0006192,nm0006197		I'd Know You Anywhere
 13	1940	Music	MUSIC (Original Song)	MUSIC (Song)	an0053030	Music in My Heart	tt0032823	Music and Lyrics by Chet Forrest and Bob Wright	Chet Forrest, Bob Wright	nm0286609,nm0942243		It's A Blue World
@@ -1151,30 +1151,30 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 13	1940	Writing	WRITING (Original Story)	WRITING (Original Story)	an0052951	Edison, the Man	tt0032432	Dore Schary, Hugo Butler	Dore Schary, Hugo Butler	nm0770196,nm0124947
 13	1940	Writing	WRITING (Original Story)	WRITING (Original Story)	an0052952	My Favorite Wife	tt0029284	Bella Spewack, Samuel Spewack, Leo McCarey	Bella Spewack, Samuel Spewack, Leo McCarey	nm0818415,nm0818416,nm0564970
 13	1940	Writing	WRITING (Original Story)	WRITING (Original Story)	an0052953	The Westerner	tt0033253	Stuart N. Lake	Stuart N. Lake	nm0482193
-13	1940	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052960	The Grapes of Wrath	tt0032551	Nunnally Johnson	Nunnally Johnson	nm0425913
-13	1940	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052961	Kitty Foyle	tt0032671	Dalton Trumbo	Dalton Trumbo	nm0874308
-13	1940	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052962	The Long Voyage Home	tt0032728	Dudley Nichols	Dudley Nichols	nm0629580
-13	1940	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052959	The Philadelphia Story	tt0032904	Donald Ogden Stewart	Donald Ogden Stewart	nm0829330	True
-13	1940	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052963	Rebecca	tt0032976	Robert E. Sherwood, Joan Harrison	Robert E. Sherwood, Joan Harrison	nm0792845,nm0365661
+13	1940	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052960	The Grapes of Wrath	tt0032551	Nunnally Johnson	Nunnally Johnson	nm0425913
+13	1940	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052961	Kitty Foyle	tt0032671	Dalton Trumbo	Dalton Trumbo	nm0874308
+13	1940	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052962	The Long Voyage Home	tt0032728	Dudley Nichols	Dudley Nichols	nm0629580
+13	1940	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052959	The Philadelphia Story	tt0032904	Donald Ogden Stewart	Donald Ogden Stewart	nm0829330	True
+13	1940	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052963	Rebecca	tt0032976	Robert E. Sherwood, Joan Harrison	Robert E. Sherwood, Joan Harrison	nm0792845,nm0365661
 13	1940	Special	SPECIAL AWARD	SPECIAL AWARD	an0053504				Bob Hope	nm0001362	True			To Bob Hope, in recognition of his unselfish services to the Motion Picture Industry.
 13	1940	Special	SPECIAL AWARD	SPECIAL AWARD	an0053505				Nathan Levinson	nm0506080	True			To Colonel Nathan Levinson for his outstanding service to the industry and the Army during the past nine years, which has made possible the present efficient mobilization of the motion picture industry facilities for the production of Army Training Films.
 13	1940	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class I)	SCIENTIFIC OR TECHNICAL AWARD (Class I)					20Th Century-Fox Film Corp., DANIEL CLARK, GROVER LAUBE, CHARLES MILLER, ROBERT W. STEVENS.		True	Camera		To 20TH CENTURY-FOX FILM CORP. for the design and construction of the 20th Century Silenced Camera, developed by DANIEL CLARK, GROVER LAUBE, CHARLES MILLER and ROBERT W. STEVENS.
 13	1940	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0053508				Warner Bros., Anton Grot	co0080422,nm0343819	True	Stage Operations		To WARNER BROS. STUDIO ART DEPARTMENT and ANTON GROT for the design and perfection of the Warner Bros. water ripple and wave illusion machine.
-14	1941	Acting	ACTOR	ACTOR	an0056798	Sergeant York	tt0034167	Gary Cooper	Gary Cooper	nm0000011	True	Alvin C. York
-14	1941	Acting	ACTOR	ACTOR	an0056799	Penny Serenade	tt0034012	Cary Grant	Cary Grant	nm0000026		Roger Adams
-14	1941	Acting	ACTOR	ACTOR	an0056800	All That Money Can Buy	tt0033532	Walter Huston	Walter Huston	nm0404158		Mr. Scratch
-14	1941	Acting	ACTOR	ACTOR	an0056801	Here Comes Mr. Jordan	tt0033712	Robert Montgomery	Robert Montgomery	nm0599910		Joe Pendleton
-14	1941	Acting	ACTOR	ACTOR	an0056802	Citizen Kane	tt0033467	Orson Welles	Orson Welles	nm0000080		Charles Foster Kane
+14	1941	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056798	Sergeant York	tt0034167	Gary Cooper	Gary Cooper	nm0000011	True	Alvin C. York
+14	1941	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056799	Penny Serenade	tt0034012	Cary Grant	Cary Grant	nm0000026		Roger Adams
+14	1941	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056800	All That Money Can Buy	tt0033532	Walter Huston	Walter Huston	nm0404158		Mr. Scratch
+14	1941	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056801	Here Comes Mr. Jordan	tt0033712	Robert Montgomery	Robert Montgomery	nm0599910		Joe Pendleton
+14	1941	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056802	Citizen Kane	tt0033467	Orson Welles	Orson Welles	nm0000080		Charles Foster Kane
 14	1941	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056809	Sergeant York	tt0034167	Walter Brennan	Walter Brennan	nm0000974		Pastor Posier Pile
 14	1941	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056810	The Devil and Miss Jones	tt0033533	Charles Coburn	Charles Coburn	nm0002013		John P. Merrick
 14	1941	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056808	How Green Was My Valley	tt0033729	Donald Crisp	Donald Crisp	nm0187981	True	Mr. Morgan
 14	1941	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056811	Here Comes Mr. Jordan	tt0033712	James Gleason	James Gleason	nm0322299		Max Corkle
 14	1941	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056812	The Maltese Falcon	tt0033870	Sydney Greenstreet	Sydney Greenstreet	nm0002113		Kaspar Gutman
-14	1941	Acting	ACTRESS	ACTRESS	an0056804	The Little Foxes	tt0033836	Bette Davis	Bette Davis	nm0000012		Regina Hubbard Giddens
-14	1941	Acting	ACTRESS	ACTRESS	an0056805	Hold Back the Dawn	tt0033722	Olivia de Havilland	Olivia de Havilland	nm0000014		Emmy Brown
-14	1941	Acting	ACTRESS	ACTRESS	an0056803	Suspicion	tt0034248	Joan Fontaine	Joan Fontaine	nm0000021	True	Lina McLaidlaw
-14	1941	Acting	ACTRESS	ACTRESS	an0056806	Blossoms in the Dust	tt0033407	Greer Garson	Greer Garson	nm0002093		Edna Gladney
-14	1941	Acting	ACTRESS	ACTRESS	an0056807	Ball of Fire	tt0033373	Barbara Stanwyck	Barbara Stanwyck	nm0001766		Sugarpuss O'Shea
+14	1941	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056804	The Little Foxes	tt0033836	Bette Davis	Bette Davis	nm0000012		Regina Hubbard Giddens
+14	1941	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056805	Hold Back the Dawn	tt0033722	Olivia de Havilland	Olivia de Havilland	nm0000014		Emmy Brown
+14	1941	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056803	Suspicion	tt0034248	Joan Fontaine	Joan Fontaine	nm0000021	True	Lina McLaidlaw
+14	1941	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056806	Blossoms in the Dust	tt0033407	Greer Garson	Greer Garson	nm0002093		Edna Gladney
+14	1941	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056807	Ball of Fire	tt0033373	Barbara Stanwyck	Barbara Stanwyck	nm0001766		Sugarpuss O'Shea
 14	1941	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056814	How Green Was My Valley	tt0033729	Sara Allgood	Sara Allgood	nm0021329		Mrs. Morgan
 14	1941	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056813	The Great Lie	tt0033677	Mary Astor	Mary Astor	nm0000802	True	Sandra Kovak
 14	1941	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056815	The Little Foxes	tt0033836	Patricia Collinge	Patricia Collinge	nm0172048		Birdie Hubbard
@@ -1333,11 +1333,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 14	1941	Writing	WRITING (Original Story)	WRITING (Original Story)	an0056825	The Lady Eve	tt0033804	Monckton Hoffe	Monckton Hoffe	nm0388743
 14	1941	Writing	WRITING (Original Story)	WRITING (Original Story)	an0056826	Meet John Doe	tt0033891	Richard Connell, Robert Presnell	Richard Connell, Robert Presnell	nm0175028,nm0696190
 14	1941	Writing	WRITING (Original Story)	WRITING (Original Story)	an0056827	Night Train	tt0032842	Gordon Wellesley	Gordon Wellesley	nm0919968
-14	1941	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056833	Here Comes Mr. Jordan	tt0033712	Sidney Buchman, Seton I. Miller	Sidney Buchman, Seton I. Miller	nm0118227,nm0589316	True
-14	1941	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056834	Hold Back the Dawn	tt0033722	Charles Brackett, Billy Wilder	Charles Brackett, Billy Wilder	nm0102818,nm0000697
-14	1941	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056835	How Green Was My Valley	tt0033729	Philip Dunne	Philip Dunne	nm0242897
-14	1941	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056836	The Little Foxes	tt0033836	Lillian Hellman	Lillian Hellman	nm0375484
-14	1941	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056837	The Maltese Falcon	tt0033870	John Huston	John Huston	nm0001379
+14	1941	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056833	Here Comes Mr. Jordan	tt0033712	Sidney Buchman, Seton I. Miller	Sidney Buchman, Seton I. Miller	nm0118227,nm0589316	True
+14	1941	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056834	Hold Back the Dawn	tt0033722	Charles Brackett, Billy Wilder	Charles Brackett, Billy Wilder	nm0102818,nm0000697
+14	1941	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056835	How Green Was My Valley	tt0033729	Philip Dunne	Philip Dunne	nm0242897
+14	1941	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056836	The Little Foxes	tt0033836	Lillian Hellman	Lillian Hellman	nm0375484
+14	1941	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056837	The Maltese Falcon	tt0033870	John Huston	John Huston	nm0001379
 14	1941	Special	SPECIAL AWARD	SPECIAL AWARD	an0048872	Kukan	tt0121453		Rey Scott	nm0721164	True			To Rey Scott for his extraordinary achievement in producing Kukan, the film record of China's struggle, including its photography with a 16mm camera under the most difficult and dangerous conditions.
 14	1941	Special	SPECIAL AWARD	SPECIAL AWARD	an0048873	Target for Tonight	tt0121791		The British Ministry of Information	?	True			To The British Ministry of Information for its vivid and dramatic presentation of the heroism of the RAF in the documentary film, Target for Tonight.
 14	1941	Special	SPECIAL AWARD	SPECIAL AWARD	an0048874	Fantasia	tt0032455		Leopold Stokowski	nm0831439	True			To Leopold Stokowski and his associates for their unique achievement in the creation of a new form of visualized music in Walt Disney's production, Fantasia, thereby widening the scope of the motion picture as entertainment and as an art form.
@@ -1350,21 +1350,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 14	1941	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Wilbur Silvertooth, Paramount		True	Special Photographic		To WILBUR SILVERTOOTH and the PARAMOUNT STUDIO ENGINEERING DEPARTMENT for the design and computation of a relay condenser system applicable to transparency process projection, delivering considerably more usable light.
 14	1941	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Paramount Pictures, 20th CENTURY-FOX Film Corp.		True	Stage Operations		To PARAMOUNT PICTURES, INC., and 20TH CENTURY-FOX FILM CORP. for the development and first practical application to motion picture production of an automatic scene slating device.
 14	1941	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0048884				Douglas Shearer, Metro-Goldwyn-Mayer, Loren Ryder, Paramount	nm0790428,co0007143,nm0753122,co0023400	True	Sound		To DOUGLAS SHEARER and the METRO-GOLDWYN-MAYER STUDIO SOUND DEPARTMENT, and to LOREN RYDER and the PARAMOUNT STUDIO SOUND DEPARTMENT for pioneering the development of fine grain emulsions for variable density original sound recording in studio production.
-15	1942	Acting	ACTOR	ACTOR	an0051614	Yankee Doodle Dandy	tt0035575	James Cagney	James Cagney	nm0000010	True	George M. Cohan
-15	1942	Acting	ACTOR	ACTOR	an0051615	Random Harvest	tt0035238	Ronald Colman	Ronald Colman	nm0172903		Charles Ranier
-15	1942	Acting	ACTOR	ACTOR	an0051616	The Pride of the Yankees	tt0035211	Gary Cooper	Gary Cooper	nm0000011		Lou Gehrig
-15	1942	Acting	ACTOR	ACTOR	an0051617	Mrs. Miniver	tt0035093	Walter Pidgeon	Walter Pidgeon	nm0682074		Clem Miniver
-15	1942	Acting	ACTOR	ACTOR	an0051618	The Pied Piper	tt0035189	Monty Woolley	Monty Woolley	nm0941253		Howard
+15	1942	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051614	Yankee Doodle Dandy	tt0035575	James Cagney	James Cagney	nm0000010	True	George M. Cohan
+15	1942	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051615	Random Harvest	tt0035238	Ronald Colman	Ronald Colman	nm0172903		Charles Ranier
+15	1942	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051616	The Pride of the Yankees	tt0035211	Gary Cooper	Gary Cooper	nm0000011		Lou Gehrig
+15	1942	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051617	Mrs. Miniver	tt0035093	Walter Pidgeon	Walter Pidgeon	nm0682074		Clem Miniver
+15	1942	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051618	The Pied Piper	tt0035189	Monty Woolley	Monty Woolley	nm0941253		Howard
 15	1942	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051625	Wake Island	tt0035530	William Bendix	William Bendix	nm0000904		Smacksie Randall
 15	1942	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051624	Johnny Eager	tt0033774	Van Heflin	Van Heflin	nm0001336	True	Jeff Hartnett
 15	1942	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051626	Yankee Doodle Dandy	tt0035575	Walter Huston	Walter Huston	nm0404158		Jerry Cohan
 15	1942	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051627	Tortilla Flat	tt0035460	Frank Morgan	Frank Morgan	nm0604656		The Pirate
 15	1942	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051628	Mrs. Miniver	tt0035093	Henry Travers	Henry Travers	nm0871287		Mr. Ballard
-15	1942	Acting	ACTRESS	ACTRESS	an0051620	Now, Voyager	tt0035140	Bette Davis	Bette Davis	nm0000012		Charlotte Vale
-15	1942	Acting	ACTRESS	ACTRESS	an0051619	Mrs. Miniver	tt0035093	Greer Garson	Greer Garson	nm0002093	True	Kay Miniver
-15	1942	Acting	ACTRESS	ACTRESS	an0051621	Woman of the Year	tt0035567	Katharine Hepburn	Katharine Hepburn	nm0000031		Tess Harding
-15	1942	Acting	ACTRESS	ACTRESS	an0051622	My Sister Eileen	tt0035105	Rosalind Russell	Rosalind Russell	nm0751426		Ruth Sherwood
-15	1942	Acting	ACTRESS	ACTRESS	an0051623	The Pride of the Yankees	tt0035211	Teresa Wright	Teresa Wright	nm0942863		Eleanor Gehrig
+15	1942	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051620	Now, Voyager	tt0035140	Bette Davis	Bette Davis	nm0000012		Charlotte Vale
+15	1942	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051619	Mrs. Miniver	tt0035093	Greer Garson	Greer Garson	nm0002093	True	Kay Miniver
+15	1942	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051621	Woman of the Year	tt0035567	Katharine Hepburn	Katharine Hepburn	nm0000031		Tess Harding
+15	1942	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051622	My Sister Eileen	tt0035105	Rosalind Russell	Rosalind Russell	nm0751426		Ruth Sherwood
+15	1942	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051623	The Pride of the Yankees	tt0035211	Teresa Wright	Teresa Wright	nm0942863		Eleanor Gehrig
 15	1942	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051630	Now, Voyager	tt0035140	Gladys Cooper	Gladys Cooper	nm0178066		Mrs. Vale
 15	1942	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051631	The Magnificent Ambersons	tt0035015	Agnes Moorehead	Agnes Moorehead	nm0001547		Fanny Minafer
 15	1942	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051632	Random Harvest	tt0035238	Susan Peters	Susan Peters	nm0676688		Kitty
@@ -1527,11 +1527,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 15	1942	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0051647	Wake Island	tt0035530	W. R. Burnett, Frank Butler	W. R. Burnett, Frank Butler	nm0122446,nm0124918
 15	1942	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0051648	The War against Mrs. Hadley	tt0035531	George Oppenheimer	George Oppenheimer	nm0649183
 15	1942	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0051644	Woman of the Year	tt0035567	Ring Lardner, Jr., Michael Kanin	Ring Lardner Jr., Michael Kanin	nm0488057,nm0437720	True
-15	1942	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0051650	The Invaders	tt0033627	Rodney Ackland, Emeric Pressburger	Rodney Ackland, Emeric Pressburger	nm0010063,nm0696247
-15	1942	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0051649	Mrs. Miniver	tt0035093	Arthur Wimperis, George Froeschel, James Hilton, Claudine West	Arthur Wimperis, George Froeschel, James Hilton, Claudine West	nm0934497,nm0296207,nm0385264,nm0921995	True
-15	1942	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0051651	The Pride of the Yankees	tt0035211	Jo Swerling, Herman J. Mankiewicz	Jo Swerling, Herman J. Mankiewicz	nm0842485,nm0542534
-15	1942	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0051652	Random Harvest	tt0035238	Claudine West, George Froeschel, Arthur Wimperis	Claudine West, George Froeschel, Arthur Wimperis	nm0921995,nm0296207,nm0934497
-15	1942	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0051653	The Talk of the Town	tt0035417	Irwin Shaw, Sidney Buchman	Irwin Shaw, Sidney Buchman	nm0789758,nm0118227
+15	1942	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0051650	The Invaders	tt0033627	Rodney Ackland, Emeric Pressburger	Rodney Ackland, Emeric Pressburger	nm0010063,nm0696247
+15	1942	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0051649	Mrs. Miniver	tt0035093	Arthur Wimperis, George Froeschel, James Hilton, Claudine West	Arthur Wimperis, George Froeschel, James Hilton, Claudine West	nm0934497,nm0296207,nm0385264,nm0921995	True
+15	1942	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0051651	The Pride of the Yankees	tt0035211	Jo Swerling, Herman J. Mankiewicz	Jo Swerling, Herman J. Mankiewicz	nm0842485,nm0542534
+15	1942	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0051652	Random Harvest	tt0035238	Claudine West, George Froeschel, Arthur Wimperis	Claudine West, George Froeschel, Arthur Wimperis	nm0921995,nm0296207,nm0934497
+15	1942	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0051653	The Talk of the Town	tt0035417	Irwin Shaw, Sidney Buchman	Irwin Shaw, Sidney Buchman	nm0789758,nm0118227
 15	1942	Special	SPECIAL AWARD	SPECIAL AWARD	an0054878				Charles Boyer	nm0000964	True			To Charles Boyer for his progressive cultural achievement in establishing the French Research Foundation in Los Angeles as a source of reference for the Hollywood Motion Picture Industry.
 15	1942	Special	SPECIAL AWARD	SPECIAL AWARD	an0054879	In Which We Serve	tt0034891		Noel Coward	nm0002021	True			To Noel Coward for his outstanding production achievement in In Which We Serve.
 15	1942	Special	SPECIAL AWARD	SPECIAL AWARD	anxxx017				Metro-Goldwyn-Mayer	co0007143	True			To Metro-Goldwyn-Mayer for its achievement in representing the American Way of Life in the production of the \"Andy Hardy\" series of films.
@@ -1540,21 +1540,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 15	1942	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0054884				DANIEL B. CLARK, the 20TH CENTURY-FOX FILM CORP.	nm0163820,?	True	Lenses and Filters		To DANIEL B. CLARK and the 20TH CENTURY-FOX FILM CORP. for the development of a lens calibration system and the application of this system to exposure control in cinematography.
 15	1942	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Robert Henderson, Paramount Studio		True	Special Photographic		To ROBERT HENDERSON and the PARAMOUNT STUDIO ENGINEERING and TRANSPARENCY DEPARTMENTS for the design and construction of adjustable light bridges and screen frames for transparency process photography.
 15	1942	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0054886				Daniel J. Bloomberg, Republic	nm0089253,co0020540	True	Laboratory		To DANIEL J. BLOOMBERG and the REPUBLIC STUDIO SOUND DEPARTMENT for the design and application to motion picture production of a device for marking action negative for pre-selection purposes.
-16	1943	Acting	ACTOR	ACTOR	an0049558	Casablanca	tt0034583	Humphrey Bogart	Humphrey Bogart	nm0000007		Rick Blane
-16	1943	Acting	ACTOR	ACTOR	an0049559	For Whom the Bell Tolls	tt0035896	Gary Cooper	Gary Cooper	nm0000011		Robert Jordan
-16	1943	Acting	ACTOR	ACTOR	an0049557	Watch on the Rhine	tt0036515	Paul Lukas	Paul Lukas	nm0510134	True	Kurt Muller
-16	1943	Acting	ACTOR	ACTOR	an0049560	Madame Curie	tt0036126	Walter Pidgeon	Walter Pidgeon	nm0682074		Pierre Curie
-16	1943	Acting	ACTOR	ACTOR	an0049561	The Human Comedy	tt0036022	Mickey Rooney	Mickey Rooney	nm0001682		Homer Macauley
+16	1943	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049558	Casablanca	tt0034583	Humphrey Bogart	Humphrey Bogart	nm0000007		Rick Blane
+16	1943	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049559	For Whom the Bell Tolls	tt0035896	Gary Cooper	Gary Cooper	nm0000011		Robert Jordan
+16	1943	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049557	Watch on the Rhine	tt0036515	Paul Lukas	Paul Lukas	nm0510134	True	Kurt Muller
+16	1943	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049560	Madame Curie	tt0036126	Walter Pidgeon	Walter Pidgeon	nm0682074		Pierre Curie
+16	1943	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049561	The Human Comedy	tt0036022	Mickey Rooney	Mickey Rooney	nm0001682		Homer Macauley
 16	1943	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049568	The Song of Bernadette	tt0036377	Charles Bickford	Charles Bickford	nm0001948		Dean Peyramale
 16	1943	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049567	The More the Merrier	tt0036172	Charles Coburn	Charles Coburn	nm0002013	True	Benjamin Dingle
 16	1943	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049569	Sahara	tt0036323	J. Carrol Naish	J. Carrol Naish	nm0619798		Giuseppe
 16	1943	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049570	Casablanca	tt0034583	Claude Rains	Claude Rains	nm0001647		Captain Louis Renault
 16	1943	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049571	For Whom the Bell Tolls	tt0035896	Akim Tamiroff	Akim Tamiroff	nm0848667		Pablo
-16	1943	Acting	ACTRESS	ACTRESS	an0049563	The More the Merrier	tt0036172	Jean Arthur	Jean Arthur	nm0000795		Connie Milligan
-16	1943	Acting	ACTRESS	ACTRESS	an0049564	For Whom the Bell Tolls	tt0035896	Ingrid Bergman	Ingrid Bergman	nm0000006		Maria
-16	1943	Acting	ACTRESS	ACTRESS	an0049565	The Constant Nymph	tt0035751	Joan Fontaine	Joan Fontaine	nm0000021		Teresa 'Tessa' Sanger
-16	1943	Acting	ACTRESS	ACTRESS	an0049566	Madame Curie	tt0036126	Greer Garson	Greer Garson	nm0002093		Madame Marie Curie
-16	1943	Acting	ACTRESS	ACTRESS	an0049562	The Song of Bernadette	tt0036377	Jennifer Jones	Jennifer Jones	nm0428354	True	Bernadette Soubirous
+16	1943	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049563	The More the Merrier	tt0036172	Jean Arthur	Jean Arthur	nm0000795		Connie Milligan
+16	1943	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049564	For Whom the Bell Tolls	tt0035896	Ingrid Bergman	Ingrid Bergman	nm0000006		Maria
+16	1943	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049565	The Constant Nymph	tt0035751	Joan Fontaine	Joan Fontaine	nm0000021		Teresa 'Tessa' Sanger
+16	1943	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049566	Madame Curie	tt0036126	Greer Garson	Greer Garson	nm0002093		Madame Marie Curie
+16	1943	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049562	The Song of Bernadette	tt0036377	Jennifer Jones	Jennifer Jones	nm0428354	True	Bernadette Soubirous
 16	1943	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049573	The Song of Bernadette	tt0036377	Gladys Cooper	Gladys Cooper	nm0178066		Sister Vauzous
 16	1943	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049574	So Proudly We Hail!	tt0036367	Paulette Goddard	Paulette Goddard	nm0002104		Lieutenant Joan O'Doul
 16	1943	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049572	For Whom the Bell Tolls	tt0035896	Katina Paxinou	Katina Paxinou	nm0668093	True	Pilar
@@ -1715,11 +1715,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 16	1943	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0049590	The North Star	tt0036217	Lillian Hellman	Lillian Hellman	nm0375484
 16	1943	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0049587	Princess O'Rourke	tt0036277	Norman Krasna	Norman Krasna	nm0469915	True
 16	1943	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0049591	So Proudly We Hail!	tt0036367	Allan Scott	Allan Scott	nm0778818
-16	1943	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049592	Casablanca	tt0034583	Julius J. Epstein, Philip G. Epstein, Howard Koch	Julius J. Epstein, Philip G. Epstein, Howard Koch	nm0258493,nm0258525,nm0462321	True
-16	1943	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049593	Holy Matrimony	tt0036009	Nunnally Johnson	Nunnally Johnson	nm0425913
-16	1943	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049594	The More the Merrier	tt0036172	Robert Russell, Frank Ross, Richard Flournoy, Lewis R. Foster	Robert Russell, Frank Ross, Richard Flournoy, Lewis R. Foster	nm0751417,nm0743407,nm0283133,nm0287931
-16	1943	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049595	The Song of Bernadette	tt0036377	George Seaton	George Seaton	nm0780833
-16	1943	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049596	Watch on the Rhine	tt0036515	Dashiell Hammett	Dashiell Hammett	nm0358591
+16	1943	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049592	Casablanca	tt0034583	Julius J. Epstein, Philip G. Epstein, Howard Koch	Julius J. Epstein, Philip G. Epstein, Howard Koch	nm0258493,nm0258525,nm0462321	True
+16	1943	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049593	Holy Matrimony	tt0036009	Nunnally Johnson	Nunnally Johnson	nm0425913
+16	1943	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049594	The More the Merrier	tt0036172	Robert Russell, Frank Ross, Richard Flournoy, Lewis R. Foster	Robert Russell, Frank Ross, Richard Flournoy, Lewis R. Foster	nm0751417,nm0743407,nm0283133,nm0287931
+16	1943	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049595	The Song of Bernadette	tt0036377	George Seaton	George Seaton	nm0780833
+16	1943	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049596	Watch on the Rhine	tt0036515	Dashiell Hammett	Dashiell Hammett	nm0358591
 16	1943	Special	SPECIAL AWARD	SPECIAL AWARD	an0054869				George Pal	nm0657162	True			To George Pal for the development of novel methods and techniques in the production of short subjects known as Puppetoons.
 16	1943	Special	IRVING G. THALBERG MEMORIAL AWARD	IRVING G. THALBERG MEMORIAL AWARD	an0054870			Hal B. Wallis	Hal B. Wallis	nm0909259	True
 16	1943	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0054872				Farciot Edouart, Earle Morgan, Barton Thompson, Paramount Studio	nm0249643,?,?,co0023400	True	Special Photographic		To FARCIOT EDOUART, EARLE MORGAN, BARTON THOMPSON and the PARAMOUNT STUDIO ENGINEERING and TRANSPARENCY DEPARTMENTS for the development and practical application to motion picture production of a method of duplicating and enlarging natural color photographs, transferring the image emulsions to glass plates and projecting these slides by especially designed stereopticon equipment.
@@ -1728,21 +1728,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 16	1943	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0054875				Charles Galloway Clarke, 20Th Century-Fox	nm0164690,co0028775	True	Photography		To CHARLES GALLOWAY CLARKE and the 20TH CENTURY-FOX STUDIO CAMERA DEPARTMENT for the development and practical application of a device for composing artificial clouds into motion picture scenes during production photography.
 16	1943	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0054876				Farciot Edouart, Paramount Studio	nm0249643,co0023400	True	Special Photographic		To FARCIOT EDOUART and the PARAMOUNT STUDIO TRANSPARENCY DEPARTMENT for an automatic electric transparency cueing timer.
 16	1943	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Willard H. Turner, Rko Radio		True	Sound		To WILLARD H. TURNER and the RKO RADIO STUDIO SOUND DEPARTMENT for the design and construction of the phono-cue starter.
-17	1944	Acting	ACTOR	ACTOR	an0052547	Gaslight	tt0036855	Charles Boyer	Charles Boyer	nm0000964		Gregory Anton
-17	1944	Acting	ACTOR	ACTOR	an0052546	Going My Way	tt0036872	Bing Crosby	Bing Crosby	nm0001078	True	Father O'Malley
-17	1944	Acting	ACTOR	ACTOR	an0052548	Going My Way	tt0036872	Barry Fitzgerald	Barry Fitzgerald	nm0280178		Father Fitzgibbon
-17	1944	Acting	ACTOR	ACTOR	an0052549	None but the Lonely Heart	tt0037135	Cary Grant	Cary Grant	nm0000026		Ernie Mott
-17	1944	Acting	ACTOR	ACTOR	an0052550	Wilson	tt0037465	Alexander Knox	Alexander Knox	nm0461594		Woodrow Wilson
+17	1944	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052547	Gaslight	tt0036855	Charles Boyer	Charles Boyer	nm0000964		Gregory Anton
+17	1944	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052546	Going My Way	tt0036872	Bing Crosby	Bing Crosby	nm0001078	True	Father O'Malley
+17	1944	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052548	Going My Way	tt0036872	Barry Fitzgerald	Barry Fitzgerald	nm0280178		Father Fitzgibbon
+17	1944	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052549	None but the Lonely Heart	tt0037135	Cary Grant	Cary Grant	nm0000026		Ernie Mott
+17	1944	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052550	Wilson	tt0037465	Alexander Knox	Alexander Knox	nm0461594		Woodrow Wilson
 17	1944	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052557	The Seventh Cross	tt0037263	Hume Cronyn	Hume Cronyn	nm0002025		Paul Roeder
 17	1944	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052556	Going My Way	tt0036872	Barry Fitzgerald	Barry Fitzgerald	nm0280178	True	Father Fitzgibbon
 17	1944	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052558	Mr. Skeffington	tt0037094	Claude Rains	Claude Rains	nm0001647		Job Skeffington
 17	1944	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052559	Laura	tt0037008	Clifton Webb	Clifton Webb	nm0916067		Waldo Lydecker
 17	1944	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052560	Since You Went Away	tt0037280	Monty Woolley	Monty Woolley	nm0941253		Colonel Smollett
-17	1944	Acting	ACTRESS	ACTRESS	an0052551	Gaslight	tt0036855	Ingrid Bergman	Ingrid Bergman	nm0000006	True	Paula Alquist
-17	1944	Acting	ACTRESS	ACTRESS	an0052552	Since You Went Away	tt0037280	Claudette Colbert	Claudette Colbert	nm0001055		Anne Hilton
-17	1944	Acting	ACTRESS	ACTRESS	an0052553	Mr. Skeffington	tt0037094	Bette Davis	Bette Davis	nm0000012		Fanny Trellis Skeffington
-17	1944	Acting	ACTRESS	ACTRESS	an0052554	Mrs. Parkington	tt0037096	Greer Garson	Greer Garson	nm0002093		Susie Parkington
-17	1944	Acting	ACTRESS	ACTRESS	an0052555	Double Indemnity	tt0036775	Barbara Stanwyck	Barbara Stanwyck	nm0001766		Phyllis Dietrichson
+17	1944	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052551	Gaslight	tt0036855	Ingrid Bergman	Ingrid Bergman	nm0000006	True	Paula Alquist
+17	1944	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052552	Since You Went Away	tt0037280	Claudette Colbert	Claudette Colbert	nm0001055		Anne Hilton
+17	1944	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052553	Mr. Skeffington	tt0037094	Bette Davis	Bette Davis	nm0000012		Fanny Trellis Skeffington
+17	1944	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052554	Mrs. Parkington	tt0037096	Greer Garson	Greer Garson	nm0002093		Susie Parkington
+17	1944	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052555	Double Indemnity	tt0036775	Barbara Stanwyck	Barbara Stanwyck	nm0001766		Phyllis Dietrichson
 17	1944	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052561	None but the Lonely Heart	tt0037135	Ethel Barrymore	Ethel Barrymore	nm0000856	True	Ma Mott
 17	1944	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052562	Since You Went Away	tt0037280	Jennifer Jones	Jennifer Jones	nm0428354		Jane Hilton
 17	1944	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052563	Gaslight	tt0036855	Angela Lansbury	Angela Lansbury	nm0001450		Nancy Oliver
@@ -1889,11 +1889,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 17	1944	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0052579	Two Girls and a Sailor	tt0037408	Richard Connell, Gladys Lehman	Richard Connell, Gladys Lehman	nm0175028,nm0499628
 17	1944	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0052576	Wilson	tt0037465	Lamar Trotti	Lamar Trotti	nm0873707	True
 17	1944	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0052580	Wing and a Prayer	tt0037466	Jerome Cady	Jerome Cady	nm0128332
-17	1944	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052582	Double Indemnity	tt0036775	Billy Wilder, Raymond Chandler	Billy Wilder, Raymond Chandler	nm0000697,nm0151452
-17	1944	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052583	Gaslight	tt0036855	John Van Druten, Walter Reisch, John L. Balderston	John Van Druten, Walter Reisch, John L. Balderston	nm0886668,nm0281556,nm0049721
-17	1944	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052581	Going My Way	tt0036872	Frank Butler, Frank Cavett	Frank Butler, Frank Cavett	nm0124918,nm0147119	True
-17	1944	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052584	Laura	tt0037008	Jay Dratler, Samuel Hoffenstein, Betty Reinhardt	Jay Dratler, Samuel Hoffenstein, Betty Reinhardt	nm0237225,nm0388755,nm0718101
-17	1944	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0052585	Meet Me in St. Louis	tt0037059	Irving Brecher, Fred F. Finklehoffe	Irving Brecher, Fred F. Finklehoffe	nm0106505,nm0277943
+17	1944	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052582	Double Indemnity	tt0036775	Billy Wilder, Raymond Chandler	Billy Wilder, Raymond Chandler	nm0000697,nm0151452
+17	1944	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052583	Gaslight	tt0036855	John Van Druten, Walter Reisch, John L. Balderston	John Van Druten, Walter Reisch, John L. Balderston	nm0886668,nm0281556,nm0049721
+17	1944	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052581	Going My Way	tt0036872	Frank Butler, Frank Cavett	Frank Butler, Frank Cavett	nm0124918,nm0147119	True
+17	1944	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052584	Laura	tt0037008	Jay Dratler, Samuel Hoffenstein, Betty Reinhardt	Jay Dratler, Samuel Hoffenstein, Betty Reinhardt	nm0237225,nm0388755,nm0718101
+17	1944	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0052585	Meet Me in St. Louis	tt0037059	Irving Brecher, Fred F. Finklehoffe	Irving Brecher, Fred F. Finklehoffe	nm0106505,nm0277943
 17	1944	Special	SPECIAL AWARD	SPECIAL AWARD	an0475546				Margaret O'Brien	nm0639684	True			To Margaret O'Brien, outstanding child actress of 1944.
 17	1944	Special	SPECIAL AWARD	SPECIAL AWARD	an0049822				Bob Hope	nm0001362	True			To Bob Hope for his many services to the Academy.
 17	1944	Special	IRVING G. THALBERG MEMORIAL AWARD	IRVING G. THALBERG MEMORIAL AWARD	an0049823			Darryl F. Zanuck	Darryl F. Zanuck	nm0953123	True
@@ -1908,21 +1908,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 17	1944	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0049833				Bernard B. Brown, John P. Livadary	nm0113094,nm0515093	True	Sound		To BERNARD B. BROWN and JOHN P. LIVADARY for the design and engineering of a separate soloist and chorus recording room.
 17	1944	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Paul Zeff, S. J. TWINING, GEORGE SEID		True	Laboratory		To PAUL ZEFF, S. J. TWINING and GEORGE SEID of the Columbia Studio Laboratory for the formula and application to production of a simplified variable area sound negative developer.
 17	1944	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0049835				Paul Lerpae	nm0503805	True	Special Photographic		To PAUL LERPAE for the design and construction of the Paramount traveling matte projection and photographing device.
-18	1945	Acting	ACTOR	ACTOR	an0055980	The Bells of St. Mary's	tt0037536	Bing Crosby	Bing Crosby	nm0001078		Father O'Malley
-18	1945	Acting	ACTOR	ACTOR	an0055981	Anchors Aweigh	tt0037514	Gene Kelly	Gene Kelly	nm0000037		Joseph Brady
-18	1945	Acting	ACTOR	ACTOR	an0055979	The Lost Weekend	tt0037884	Ray Milland	Ray Milland	nm0001537	True	Don Birnam
-18	1945	Acting	ACTOR	ACTOR	an0055982	The Keys of the Kingdom	tt0036983	Gregory Peck	Gregory Peck	nm0000060		Father Francis Chisholm
-18	1945	Acting	ACTOR	ACTOR	an0055983	A Song to Remember	tt0038104	Cornel Wilde	Cornel Wilde	nm0664273		Frederick Chopin
+18	1945	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055980	The Bells of St. Mary's	tt0037536	Bing Crosby	Bing Crosby	nm0001078		Father O'Malley
+18	1945	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055981	Anchors Aweigh	tt0037514	Gene Kelly	Gene Kelly	nm0000037		Joseph Brady
+18	1945	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055979	The Lost Weekend	tt0037884	Ray Milland	Ray Milland	nm0001537	True	Don Birnam
+18	1945	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055982	The Keys of the Kingdom	tt0036983	Gregory Peck	Gregory Peck	nm0000060		Father Francis Chisholm
+18	1945	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055983	A Song to Remember	tt0038104	Cornel Wilde	Cornel Wilde	nm0664273		Frederick Chopin
 18	1945	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055990	Spellbound	tt0038109	Michael Chekhov	Michael Chekhov	nm0155011		Dr. Alex Brulov
 18	1945	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055991	The Corn Is Green	tt0037614	John Dall	John Dall	nm0197982		Morgan Evans
 18	1945	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055989	A Tree Grows in Brooklyn	tt0038190	James Dunn	James Dunn	nm0007223	True	Johnny Nolan
 18	1945	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055992	G. I. Joe	tt0038120	Robert Mitchum	Robert Mitchum	nm0000053		Lieutenant Walker
 18	1945	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055993	A Medal for Benny	tt0037906	J. Carrol Naish	J. Carrol Naish	nm0619798		Charlie Martini
-18	1945	Acting	ACTRESS	ACTRESS	an0055985	The Bells of St. Mary's	tt0037536	Ingrid Bergman	Ingrid Bergman	nm0000006		Sister Benedict
-18	1945	Acting	ACTRESS	ACTRESS	an0055984	Mildred Pierce	tt0037913	Joan Crawford	Joan Crawford	nm0001076	True	Mildred Pierce
-18	1945	Acting	ACTRESS	ACTRESS	an0055986	The Valley of Decision	tt0038213	Greer Garson	Greer Garson	nm0002093		Mary Rafferty
-18	1945	Acting	ACTRESS	ACTRESS	an0055987	Love Letters	tt0037885	Jennifer Jones	Jennifer Jones	nm0428354		Singleton
-18	1945	Acting	ACTRESS	ACTRESS	an0055988	Leave Her to Heaven	tt0037865	Gene Tierney	Gene Tierney	nm0000074		Ellen Berent
+18	1945	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055985	The Bells of St. Mary's	tt0037536	Ingrid Bergman	Ingrid Bergman	nm0000006		Sister Benedict
+18	1945	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055984	Mildred Pierce	tt0037913	Joan Crawford	Joan Crawford	nm0001076	True	Mildred Pierce
+18	1945	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055986	The Valley of Decision	tt0038213	Greer Garson	Greer Garson	nm0002093		Mary Rafferty
+18	1945	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055987	Love Letters	tt0037885	Jennifer Jones	Jennifer Jones	nm0428354		Singleton
+18	1945	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055988	Leave Her to Heaven	tt0037865	Gene Tierney	Gene Tierney	nm0000074		Ellen Berent
 18	1945	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055995	Mildred Pierce	tt0037913	Eve Arden	Eve Arden	nm0000781		Ida
 18	1945	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055996	Mildred Pierce	tt0037913	Ann Blyth	Ann Blyth	nm0001955		Veda Pierce
 18	1945	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055997	The Picture of Dorian Gray	tt0037988	Angela Lansbury	Angela Lansbury	nm0001450		Sibyl Vane
@@ -2059,32 +2059,32 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 18	1945	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0056011	Music for Millions	tt0037104	Myles Connolly	Myles Connolly	nm0175333
 18	1945	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0056012	Salty O'Rourke	tt0038047	Milton Holmes	Milton Holmes	nm0391972
 18	1945	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0056013	What Next, Corporal Hargrove?	tt0038243	Harry Kurnitz	Harry Kurnitz	nm0475823
-18	1945	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056017	G. I. Joe	tt0038120	Leopold Atlas, Guy Endore, Philip Stevenson	Leopold Atlas, Guy Endore, Philip Stevenson	nm0040852,nm0256880,nm0829029
-18	1945	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056014	The Lost Weekend	tt0037884	Charles Brackett, Billy Wilder	Charles Brackett, Billy Wilder	nm0102818,nm0000697	True
-18	1945	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056015	Mildred Pierce	tt0037913	Ranald MacDougall	Ranald MacDougall	nm0532030
-18	1945	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056016	Pride of the Marines	tt0038000	Albert Maltz	Albert Maltz	nm0540816
-18	1945	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056018	A Tree Grows in Brooklyn	tt0038190	Tess Slesinger, Frank Davis	Tess Slesinger, Frank Davis	nm0805756,nm0204608
+18	1945	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056017	G. I. Joe	tt0038120	Leopold Atlas, Guy Endore, Philip Stevenson	Leopold Atlas, Guy Endore, Philip Stevenson	nm0040852,nm0256880,nm0829029
+18	1945	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056014	The Lost Weekend	tt0037884	Charles Brackett, Billy Wilder	Charles Brackett, Billy Wilder	nm0102818,nm0000697	True
+18	1945	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056015	Mildred Pierce	tt0037913	Ranald MacDougall	Ranald MacDougall	nm0532030
+18	1945	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056016	Pride of the Marines	tt0038000	Albert Maltz	Albert Maltz	nm0540816
+18	1945	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056018	A Tree Grows in Brooklyn	tt0038190	Tess Slesinger, Frank Davis	Tess Slesinger, Frank Davis	nm0805756,nm0204608
 18	1945	Special	SPECIAL AWARD	SPECIAL AWARD	an0047707				Walter Wanger	nm0911137	True			To Walter Wanger for his six years service as President of the Academy of Motion Picture Arts and Sciences.
 18	1945	Special	SPECIAL AWARD	SPECIAL AWARD	an0047708				Peggy Ann Garner	nm0307750	True			To Peggy Ann Garner, outstanding child actress of 1945.
 18	1945	Special	SPECIAL AWARD	SPECIAL AWARD	an0411618	The House I Live In	tt0037792		Frank Ross, Mervyn LeRoy, Albert Maltz, Earl Robinson, Lewis Allan, Frank Sinatra, RKO Radio	nm0743407,nm0503777,nm0540816,nm0732581,nm0019977,nm0000069,co0041421	True			To The House I Live In, tolerance short subject; produced by Frank Ross and Mervyn LeRoy; directed by Mervyn LeRoy; screenplay by Albert Maltz; song \"The House I Live In,\" music by Earl Robinson, lyrics by Lewis Allan; starring Frank Sinatra; released by RKO Radio.
 18	1945	Special	SPECIAL AWARD	SPECIAL AWARD	an0047710				Republic Studio, Daniel J. Bloomberg	co0424911,nm0089253	True			To Republic Studio, Daniel J. Bloomberg and the Republic Studio Sound Department for the building of an outstanding musical scoring auditorium which provides optimum recording conditions and combines all elements of acoustic and engineering design.
 18	1945	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0047713				Loren L. Ryder, Charles R. Daily, Paramount	nm0753122,?,co0023400	True	Sound		To LOREN L. RYDER, CHARLES R. DAILY and the PARAMOUNT STUDIO SOUND DEPARTMENT for the design, construction and use of the first dial controlled step-by-step sound channel line-up and test circuit.
 18	1945	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Michael S. Leshing, BENJAMIN C. ROBINSON, ARTHUR B. CHATELAIN, ROBERT C. STEVENS, JOHN G. CAPSTAFF		True	Laboratory		To MICHAEL S. LESHING, BENJAMIN C. ROBINSON, ARTHUR B. CHATELAIN and ROBERT C. STEVENS of 20th Century-Fox Studio and JOHN G. CAPSTAFF of Eastman Kodak Company for the 20th Century-Fox film processing machine.
-19	1946	Acting	ACTOR	ACTOR	an0047573	The Best Years of Our Lives	tt0036868	Fredric March	Fredric March	nm0545298	True	Al Stephenson
-19	1946	Acting	ACTOR	ACTOR	an0047574	Henry V	tt0036910	Laurence Olivier	Laurence Olivier	nm0000059		Henry V
-19	1946	Acting	ACTOR	ACTOR	an0047575	The Jolson Story	tt0038661	Larry Parks	Larry Parks	nm0662972		Al Jolson
-19	1946	Acting	ACTOR	ACTOR	an0047576	The Yearling	tt0039111	Gregory Peck	Gregory Peck	nm0000060		Pa Baxter
-19	1946	Acting	ACTOR	ACTOR	an0047577	It's a Wonderful Life	tt0038650	James Stewart	James Stewart	nm0000071		George Bailey
+19	1946	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047573	The Best Years of Our Lives	tt0036868	Fredric March	Fredric March	nm0545298	True	Al Stephenson
+19	1946	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047574	Henry V	tt0036910	Laurence Olivier	Laurence Olivier	nm0000059		Henry V
+19	1946	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047575	The Jolson Story	tt0038661	Larry Parks	Larry Parks	nm0662972		Al Jolson
+19	1946	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047576	The Yearling	tt0039111	Gregory Peck	Gregory Peck	nm0000060		Pa Baxter
+19	1946	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0047577	It's a Wonderful Life	tt0038650	James Stewart	James Stewart	nm0000071		George Bailey
 19	1946	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047584	The Green Years	tt0038578	Charles Coburn	Charles Coburn	nm0002013		Alexander Gow
 19	1946	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047585	The Jolson Story	tt0038661	William Demarest	William Demarest	nm0218131		Steve Martin
 19	1946	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047586	Notorious	tt0038787	Claude Rains	Claude Rains	nm0001647		Alexander Sebastian
 19	1946	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047583	The Best Years of Our Lives	tt0036868	Harold Russell	Harold Russell	nm0751174	True	Homer Parrish
 19	1946	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0047587	The Razor's Edge	tt0038873	Clifton Webb	Clifton Webb	nm0916067		Elliott Templeton
-19	1946	Acting	ACTRESS	ACTRESS	an0047578	To Each His Own	tt0039040	Olivia de Havilland	Olivia de Havilland	nm0000014	True	Jody Norris
-19	1946	Acting	ACTRESS	ACTRESS	an0047579	Brief Encounter	tt0037558	Celia Johnson	Celia Johnson	nm0424743		Laura Jesson
-19	1946	Acting	ACTRESS	ACTRESS	an0047580	Duel in the Sun	tt0038499	Jennifer Jones	Jennifer Jones	nm0428354		Pearl Chavez
-19	1946	Acting	ACTRESS	ACTRESS	an0047581	Sister Kenny	tt0038948	Rosalind Russell	Rosalind Russell	nm0751426		Elizabeth Kenny
-19	1946	Acting	ACTRESS	ACTRESS	an0047582	The Yearling	tt0039111	Jane Wyman	Jane Wyman	nm0943837		Ma Baxter
+19	1946	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047578	To Each His Own	tt0039040	Olivia de Havilland	Olivia de Havilland	nm0000014	True	Jody Norris
+19	1946	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047579	Brief Encounter	tt0037558	Celia Johnson	Celia Johnson	nm0424743		Laura Jesson
+19	1946	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047580	Duel in the Sun	tt0038499	Jennifer Jones	Jennifer Jones	nm0428354		Pearl Chavez
+19	1946	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047581	Sister Kenny	tt0038948	Rosalind Russell	Rosalind Russell	nm0751426		Elizabeth Kenny
+19	1946	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0047582	The Yearling	tt0039111	Jane Wyman	Jane Wyman	nm0943837		Ma Baxter
 19	1946	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047589	The Spiral Staircase	tt0038975	Ethel Barrymore	Ethel Barrymore	nm0000856		Mrs. Warren
 19	1946	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047588	The Razor's Edge	tt0038873	Anne Baxter	Anne Baxter	nm0000879	True	Sophie MacDonald
 19	1946	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0047590	Duel in the Sun	tt0038499	Lillian Gish	Lillian Gish	nm0001273		Belle McCanles
@@ -2164,11 +2164,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 19	1946	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0047606	Notorious	tt0038787	Ben Hecht	Ben Hecht	nm0372942
 19	1946	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0047607	Road to Utopia	tt0038032	Norman Panama, Melvin Frank	Norman Panama, Melvin Frank	nm0659085,nm0291035
 19	1946	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0047603	The Seventh Veil	tt0038924	Muriel Box, Sydney Box	Muriel Box, Sydney Box	nm0101504,nm0101511	True
-19	1946	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047609	Anna and the King of Siam	tt0038303	Talbot Jennings, Sally Benson	Talbot Jennings, Sally Benson	nm0421255,nm0072639
-19	1946	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047608	The Best Years of Our Lives	tt0036868	Robert E. Sherwood	Robert E. Sherwood	nm0792845	True
-19	1946	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047610	Brief Encounter	tt0037558	David Lean, Anthony Havelock-Allan, Ronald Neame	David Lean, Anthony Havelock-Allan, Ronald Neame	nm0000180,nm0369743,nm0623768
-19	1946	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047611	The Killers	tt0038669	Anthony Veiller	Anthony Veiller	nm0892044
-19	1946	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0047612	Open City	tt0038890	Sergio Amidei, F. Fellini	Sergio Amidei, F. Fellini	nm0024847,nm0000019
+19	1946	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047609	Anna and the King of Siam	tt0038303	Talbot Jennings, Sally Benson	Talbot Jennings, Sally Benson	nm0421255,nm0072639
+19	1946	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047608	The Best Years of Our Lives	tt0036868	Robert E. Sherwood	Robert E. Sherwood	nm0792845	True
+19	1946	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047610	Brief Encounter	tt0037558	David Lean, Anthony Havelock-Allan, Ronald Neame	David Lean, Anthony Havelock-Allan, Ronald Neame	nm0000180,nm0369743,nm0623768
+19	1946	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047611	The Killers	tt0038669	Anthony Veiller	Anthony Veiller	nm0892044
+19	1946	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0047612	Open City	tt0038890	Sergio Amidei, F. Fellini	Sergio Amidei, F. Fellini	nm0024847,nm0000019
 19	1946	Special	SPECIAL AWARD	SPECIAL AWARD	an0052068	Henry V	tt0036910		Laurence Olivier	nm0000059	True			To Laurence Olivier for his outstanding achievement as actor, producer and director in bringing Henry V to the screen.
 19	1946	Special	SPECIAL AWARD	SPECIAL AWARD	an0052069	The Best Years of Our Lives	tt0036868		Harold Russell	nm0751174	True			To Harold Russell for bringing hope and courage to his fellow veterans through his appearance in The Best Years of Our Lives.
 19	1946	Special	SPECIAL AWARD	SPECIAL AWARD	an0052070				Ernst Lubitsch	nm0523932	True			To Ernst Lubitsch for his distinguished contributions to the art of the motion picture.
@@ -2183,21 +2183,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 19	1946	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Burton F. Miller, Warner Bros.		True	Sound		To BURTON F. MILLER and the WARNER BROS. STUDIO SOUND DEPARTMENT for the design and application of an equalizer to eliminate relative spectral energy distortion in electronic compressors.
 19	1946	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					MARTY MARTIN, HAL ADKINS		True	Stage Operations		To MARTY MARTIN and HAL ADKINS of the RKO Radio Studio Miniature Department for the design and construction of equipment providing visual bullet effects.
 19	1946	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Harold Nye, Warner Bros.		True	Stage Operations		To HAROLD NYE and the WARNER BROS. STUDIO ELECTRICAL DEPARTMENT for the development of the electronically controlled fire and gaslight effect.
-20	1947	Acting	ACTOR	ACTOR	an0048659	A Double Life	tt0039335	Ronald Colman	Ronald Colman	nm0172903	True	Anthony John
-20	1947	Acting	ACTOR	ACTOR	an0048660	Body and Soul	tt0039204	John Garfield	John Garfield	nm0002092		Charlie Davis
-20	1947	Acting	ACTOR	ACTOR	an0048661	Gentleman's Agreement	tt0039416	Gregory Peck	Gregory Peck	nm0000060		Phil Green
-20	1947	Acting	ACTOR	ACTOR	an0048662	Life with Father	tt0039566	William Powell	William Powell	nm0001635		Clarence Day
-20	1947	Acting	ACTOR	ACTOR	an0048663	Mourning Becomes Electra	tt0039636	Michael Redgrave	Michael Redgrave	nm0714878		Orin Mannon
+20	1947	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048659	A Double Life	tt0039335	Ronald Colman	Ronald Colman	nm0172903	True	Anthony John
+20	1947	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048660	Body and Soul	tt0039204	John Garfield	John Garfield	nm0002092		Charlie Davis
+20	1947	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048661	Gentleman's Agreement	tt0039416	Gregory Peck	Gregory Peck	nm0000060		Phil Green
+20	1947	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048662	Life with Father	tt0039566	William Powell	William Powell	nm0001635		Clarence Day
+20	1947	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048663	Mourning Becomes Electra	tt0039636	Michael Redgrave	Michael Redgrave	nm0714878		Orin Mannon
 20	1947	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048670	The Farmer's Daughter	tt0039370	Charles Bickford	Charles Bickford	nm0001948		Clancy
 20	1947	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048671	Ride the Pink Horse	tt0039768	Thomas Gomez	Thomas Gomez	nm0327089		Pancho
 20	1947	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048669	Miracle on 34th Street	tt0039628	Edmund Gwenn	Edmund Gwenn	nm0350324	True	Kris Kringle
 20	1947	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048672	Crossfire	tt0039286	Robert Ryan	Robert Ryan	nm0752813		Montgomery
 20	1947	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048673	Kiss of Death	tt0039536	Richard Widmark	Richard Widmark	nm0001847		Tommy Udo
-20	1947	Acting	ACTRESS	ACTRESS	an0048665	Possessed	tt0039725	Joan Crawford	Joan Crawford	nm0001076		Louise Howell
-20	1947	Acting	ACTRESS	ACTRESS	an0048666	Smash-Up--The Story of a Woman	tt0039840	Susan Hayward	Susan Hayward	nm0001333		Angie
-20	1947	Acting	ACTRESS	ACTRESS	an0048667	Gentleman's Agreement	tt0039416	Dorothy McGuire	Dorothy McGuire	nm0570192		Kathy
-20	1947	Acting	ACTRESS	ACTRESS	an0048668	Mourning Becomes Electra	tt0039636	Rosalind Russell	Rosalind Russell	nm0751426		Lavinia Mannon
-20	1947	Acting	ACTRESS	ACTRESS	an0048664	The Farmer's Daughter	tt0039370	Loretta Young	Loretta Young	nm0949835	True	Katrin Holstrom
+20	1947	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048665	Possessed	tt0039725	Joan Crawford	Joan Crawford	nm0001076		Louise Howell
+20	1947	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048666	Smash-Up--The Story of a Woman	tt0039840	Susan Hayward	Susan Hayward	nm0001333		Angie
+20	1947	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048667	Gentleman's Agreement	tt0039416	Dorothy McGuire	Dorothy McGuire	nm0570192		Kathy
+20	1947	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048668	Mourning Becomes Electra	tt0039636	Rosalind Russell	Rosalind Russell	nm0751426		Lavinia Mannon
+20	1947	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048664	The Farmer's Daughter	tt0039370	Loretta Young	Loretta Young	nm0949835	True	Katrin Holstrom
 20	1947	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048675	The Paradine Case	tt0039694	Ethel Barrymore	Ethel Barrymore	nm0000856		Lady Sophie Horfield
 20	1947	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048676	Crossfire	tt0039286	Gloria Grahame	Gloria Grahame	nm0002108		Ginny Tremaine
 20	1947	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048674	Gentleman's Agreement	tt0039416	Celeste Holm	Celeste Holm	nm0002141	True	Anne
@@ -2279,11 +2279,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 20	1947	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0048691	A Double Life	tt0039335	Ruth Gordon, Garson Kanin	Ruth Gordon, Garson Kanin	nm0002106,nm0437717
 20	1947	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0048692	Monsieur Verdoux	tt0039631	Charles Chaplin	Charles Chaplin	nm0000122
 20	1947	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0048693	Shoe-Shine	tt0038913	Sergio Amidei, Adolfo Franci, C. G. Viola, Cesare Zavattini	Sergio Amidei, Adolfo Franci, C. G. Viola, Cesare Zavattini	nm0024847,nm0290000,nm0899170,nm0953790
-20	1947	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0048695	Boomerang!	tt0039208	Richard Murphy	Richard Murphy	nm0614645
-20	1947	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0048696	Crossfire	tt0039286	John Paxton	John Paxton	nm0668122
-20	1947	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0048697	Gentleman's Agreement	tt0039416	Moss Hart	Moss Hart	nm0366454
-20	1947	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0048698	Great Expectations	tt0038574	David Lean, Anthony Havelock-Allan, Ronald Neame	David Lean, Anthony Havelock-Allan, Ronald Neame	nm0000180,nm0369743,nm0623768
-20	1947	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0048694	Miracle on 34th Street	tt0039628	George Seaton	George Seaton	nm0780833	True
+20	1947	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0048695	Boomerang!	tt0039208	Richard Murphy	Richard Murphy	nm0614645
+20	1947	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0048696	Crossfire	tt0039286	John Paxton	John Paxton	nm0668122
+20	1947	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0048697	Gentleman's Agreement	tt0039416	Moss Hart	Moss Hart	nm0366454
+20	1947	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0048698	Great Expectations	tt0038574	David Lean, Anthony Havelock-Allan, Ronald Neame	David Lean, Anthony Havelock-Allan, Ronald Neame	nm0000180,nm0369743,nm0623768
+20	1947	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0048694	Miracle on 34th Street	tt0039628	George Seaton	George Seaton	nm0780833	True
 20	1947	Special	SPECIAL AWARD	SPECIAL AWARD	an0056663	Song of the South	tt0038969		James Baskett	nm0059934	True			To James Baskett for his able and heart-warming characterization of Uncle Remus, friend and story teller to the children of the world in Walt Disney's Song of the South.
 20	1947	Special	SPECIAL AWARD	SPECIAL AWARD	an0056664	Bill and Coo	tt0039188				True			To Bill and Coo, in which artistry and patience blended in a novel and entertaining use of the medium of motion pictures.
 20	1947	Special	SPECIAL AWARD	SPECIAL AWARD	an0056665	Shoe-Shine	tt0038913				True			To Shoe-Shine - the high quality of this motion picture, brought to eloquent life in a country scarred by war, is proof to the world that the creative spirit can triumph over adversity.
@@ -2295,21 +2295,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 20	1947	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					FRED PONEDEL		True	Special Photographic		To FRED PONEDEL of Warner Bros. Studio for pioneering the fabrication and practical application to motion picture color photography of large translucent photographic backgrounds.
 20	1947	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Kurt Singer, Radio Corporation Of America		True	Sound		To KURT SINGER and the RCA VICTOR DIVISION OF RADIO CORPORATION OF AMERICA for the design and development of a continuously variable band-elimination filter.
 20	1947	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0056674				JAMES GIBBONS	nm0316559	True	Lighting		To JAMES GIBBONS of Warner Bros. Studio for the development and production of large dyed plastic filters for motion picture photography.
-21	1948	Acting	ACTOR	ACTOR	an0049979	Johnny Belinda	tt0040495	Lew Ayres	Lew Ayres	nm0000817		Dr. Robert Richardson
-21	1948	Acting	ACTOR	ACTOR	an0049980	The Search	tt0040765	Montgomery Clift	Montgomery Clift	nm0001050		Ralph Stevenson
-21	1948	Acting	ACTOR	ACTOR	an0049981	When My Baby Smiles at Me	tt0040962	Dan Dailey	Dan Dailey	nm0197314		Skid
-21	1948	Acting	ACTOR	ACTOR	an0049978	Hamlet	tt0040416	Laurence Olivier	Laurence Olivier	nm0000059	True	Hamlet
-21	1948	Acting	ACTOR	ACTOR	an0049982	Sitting Pretty	tt0040795	Clifton Webb	Clifton Webb	nm0916067		Lynn Belvedere
+21	1948	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049979	Johnny Belinda	tt0040495	Lew Ayres	Lew Ayres	nm0000817		Dr. Robert Richardson
+21	1948	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049980	The Search	tt0040765	Montgomery Clift	Montgomery Clift	nm0001050		Ralph Stevenson
+21	1948	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049981	When My Baby Smiles at Me	tt0040962	Dan Dailey	Dan Dailey	nm0197314		Skid
+21	1948	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049978	Hamlet	tt0040416	Laurence Olivier	Laurence Olivier	nm0000059	True	Hamlet
+21	1948	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049982	Sitting Pretty	tt0040795	Clifton Webb	Clifton Webb	nm0916067		Lynn Belvedere
 21	1948	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049989	Johnny Belinda	tt0040495	Charles Bickford	Charles Bickford	nm0001948		Black McDonald
 21	1948	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049990	Joan of Arc	tt0040491	José Ferrer	José Ferrer	nm0001207		The Dauphin, Charles VIII
 21	1948	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049991	I Remember Mama	tt0040458	Oscar Homolka	Oscar Homolka	nm0393028		Uncle Chris
 21	1948	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049988	The Treasure of the Sierra Madre	tt0040897	Walter Huston	Walter Huston	nm0404158	True	Howard
 21	1948	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049992	The Luck of the Irish	tt0040553	Cecil Kellaway	Cecil Kellaway	nm0445523		Horace
-21	1948	Acting	ACTRESS	ACTRESS	an0049984	Joan of Arc	tt0040491	Ingrid Bergman	Ingrid Bergman	nm0000006		Joan of Arc
-21	1948	Acting	ACTRESS	ACTRESS	an0049985	The Snake Pit	tt0040806	Olivia de Havilland	Olivia de Havilland	nm0000014		Virginia Stuart Cunningham
-21	1948	Acting	ACTRESS	ACTRESS	an0049986	I Remember Mama	tt0040458	Irene Dunne	Irene Dunne	nm0002050		Mama
-21	1948	Acting	ACTRESS	ACTRESS	an0049987	Sorry, Wrong Number	tt0040823	Barbara Stanwyck	Barbara Stanwyck	nm0001766		Leona Stevenson
-21	1948	Acting	ACTRESS	ACTRESS	an0049983	Johnny Belinda	tt0040495	Jane Wyman	Jane Wyman	nm0943837	True	Belinda McDonald
+21	1948	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049984	Joan of Arc	tt0040491	Ingrid Bergman	Ingrid Bergman	nm0000006		Joan of Arc
+21	1948	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049985	The Snake Pit	tt0040806	Olivia de Havilland	Olivia de Havilland	nm0000014		Virginia Stuart Cunningham
+21	1948	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049986	I Remember Mama	tt0040458	Irene Dunne	Irene Dunne	nm0002050		Mama
+21	1948	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049987	Sorry, Wrong Number	tt0040823	Barbara Stanwyck	Barbara Stanwyck	nm0001766		Leona Stevenson
+21	1948	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049983	Johnny Belinda	tt0040495	Jane Wyman	Jane Wyman	nm0943837	True	Belinda McDonald
 21	1948	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049994	I Remember Mama	tt0040458	Barbara Bel Geddes	Barbara Bel Geddes	nm0000895		Katrin
 21	1948	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049995	I Remember Mama	tt0040458	Ellen Corby	Ellen Corby	nm0179289		Aunt Trina
 21	1948	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049996	Johnny Belinda	tt0040495	Agnes Moorehead	Agnes Moorehead	nm0001547		Aggie McDonald
@@ -2392,11 +2392,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 21	1948	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050006	Red River	tt0040724	Borden Chase	Borden Chase	nm0153698
 21	1948	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050007	The Red Shoes	tt0040725	Emeric Pressburger	Emeric Pressburger	nm0696247
 21	1948	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050003	The Search	tt0040765	Richard Schweizer, David Wechsler	Richard Schweizer, David Wechsler	nm0777849,nm0917047	True
-21	1948	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050009	A Foreign Affair	tt0040367	Charles Brackett, Billy Wilder, Richard L. Breen	Charles Brackett, Billy Wilder, Richard L. Breen	nm0102818,nm0000697,nm0106764
-21	1948	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050010	Johnny Belinda	tt0040495	Irmgard Von Cube, Allen Vincent	Irmgard Von Cube, Allen Vincent	nm0902121,nm0898573
-21	1948	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050011	The Search	tt0040765	Richard Schweizer, David Wechsler	Richard Schweizer, David Wechsler	nm0777849,nm0917047
-21	1948	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050012	The Snake Pit	tt0040806	Frank Partos, Millen Brand	Frank Partos, Millen Brand	nm0664022,nm0104503
-21	1948	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050008	The Treasure of the Sierra Madre	tt0040897	John Huston	John Huston	nm0001379	True
+21	1948	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050009	A Foreign Affair	tt0040367	Charles Brackett, Billy Wilder, Richard L. Breen	Charles Brackett, Billy Wilder, Richard L. Breen	nm0102818,nm0000697,nm0106764
+21	1948	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050010	Johnny Belinda	tt0040495	Irmgard Von Cube, Allen Vincent	Irmgard Von Cube, Allen Vincent	nm0902121,nm0898573
+21	1948	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050011	The Search	tt0040765	Richard Schweizer, David Wechsler	Richard Schweizer, David Wechsler	nm0777849,nm0917047
+21	1948	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050012	The Snake Pit	tt0040806	Frank Partos, Millen Brand	Frank Partos, Millen Brand	nm0664022,nm0104503
+21	1948	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050008	The Treasure of the Sierra Madre	tt0040897	John Huston	John Huston	nm0001379	True
 21	1948	Special	SPECIAL FOREIGN LANGUAGE FILM AWARD	SPECIAL FOREIGN LANGUAGE FILM AWARD	an0054519	Monsieur Vincent	tt0039632				True			To Monsieur Vincent - voted by the Academy Board of Governors as the most outstanding foreign language film released in the United States during 1948.
 21	1948	Special	SPECIAL AWARD	SPECIAL AWARD	an0054520	The Search	tt0040765		Ivan Jandl	nm0417389	True			To Ivan Jandl, for the outstanding juvenile performance of 1948, as \"Karel Malik\" in The Search.
 21	1948	Special	SPECIAL AWARD	SPECIAL AWARD	an0054521				Sid Grauman	nm0336138	True			To Sid Grauman, master showman, who raised the standard of exhibition of motion pictures.
@@ -2408,21 +2408,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 21	1948	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0054527				Nick Kalten, Louis J. Witte, 20Th Century-Fox	?,nm0936951,co0028775	True	Props		To NICK KALTEN, LOUIS J. WITTE and the 20TH CENTURY-FOX STUDIO MECHANICAL EFFECTS DEPARTMENT for a process of preserving and flame-proofing foliage.
 21	1948	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0054528				Marty Martin, Jack Lannon, Russell Shearman, Rko Radio	?,nm0486923,nm0790480,co0041421	True	Stage Operations		To MARTY MARTIN, JACK LANNON, RUSSELL SHEARMAN and the RKO RADIO STUDIO SPECIAL EFFECTS DEPARTMENT for the development of a new method of simulating falling snow on motion picture sets.
 21	1948	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					A. J. Moran, Warner Bros.		True	Lighting		To A. J. MORAN and the WARNER BROS. STUDIO ELECTRICAL DEPARTMENT for a method of remote control for shutters on motion picture arc lighting equipment.
-22	1949	Acting	ACTOR	ACTOR	an0056135	All the King's Men	tt0041113	Broderick Crawford	Broderick Crawford	nm0002024	True	Willie Stark
-22	1949	Acting	ACTOR	ACTOR	an0056136	Champion	tt0041239	Kirk Douglas	Kirk Douglas	nm0000018		Midge Kelly
-22	1949	Acting	ACTOR	ACTOR	an0056137	Twelve O'Clock High	tt0041996	Gregory Peck	Gregory Peck	nm0000060		General Savage
-22	1949	Acting	ACTOR	ACTOR	an0056138	The Hasty Heart	tt0041445	Richard Todd	Richard Todd	nm0865262		Lachie
-22	1949	Acting	ACTOR	ACTOR	an0056139	Sands of Iwo Jima	tt0041841	John Wayne	John Wayne	nm0000078		Sergeant John M. Stryker
+22	1949	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056135	All the King's Men	tt0041113	Broderick Crawford	Broderick Crawford	nm0002024	True	Willie Stark
+22	1949	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056136	Champion	tt0041239	Kirk Douglas	Kirk Douglas	nm0000018		Midge Kelly
+22	1949	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056137	Twelve O'Clock High	tt0041996	Gregory Peck	Gregory Peck	nm0000060		General Savage
+22	1949	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056138	The Hasty Heart	tt0041445	Richard Todd	Richard Todd	nm0865262		Lachie
+22	1949	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056139	Sands of Iwo Jima	tt0041841	John Wayne	John Wayne	nm0000078		Sergeant John M. Stryker
 22	1949	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056146	All the King's Men	tt0041113	John Ireland	John Ireland	nm0409869		Jack Burden
 22	1949	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056145	Twelve O'Clock High	tt0041996	Dean Jagger	Dean Jagger	nm0415591	True	Major Stovall
 22	1949	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056147	Champion	tt0041239	Arthur Kennedy	Arthur Kennedy	nm0447913		Connie Kelly
 22	1949	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056148	The Heiress	tt0041452	Ralph Richardson	Ralph Richardson	nm0724732		Dr. Austin Sloper
 22	1949	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056149	Battleground	tt0041163	James Whitmore	James Whitmore	nm0926235		Kinnie
-22	1949	Acting	ACTRESS	ACTRESS	an0056141	Pinky	tt0041746	Jeanne Crain	Jeanne Crain	nm0002022		Pinky
-22	1949	Acting	ACTRESS	ACTRESS	an0056140	The Heiress	tt0041452	Olivia de Havilland	Olivia de Havilland	nm0000014	True	Catherine Sloper
-22	1949	Acting	ACTRESS	ACTRESS	an0056142	My Foolish Heart	tt0041672	Susan Hayward	Susan Hayward	nm0001333		Eloise Winters
-22	1949	Acting	ACTRESS	ACTRESS	an0056143	Edward, My Son	tt0041329	Deborah Kerr	Deborah Kerr	nm0000039		Evelyn Boult
-22	1949	Acting	ACTRESS	ACTRESS	an0056144	Come to the Stable	tt0041257	Loretta Young	Loretta Young	nm0949835		Sister Margaret
+22	1949	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056141	Pinky	tt0041746	Jeanne Crain	Jeanne Crain	nm0002022		Pinky
+22	1949	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056140	The Heiress	tt0041452	Olivia de Havilland	Olivia de Havilland	nm0000014	True	Catherine Sloper
+22	1949	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056142	My Foolish Heart	tt0041672	Susan Hayward	Susan Hayward	nm0001333		Eloise Winters
+22	1949	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056143	Edward, My Son	tt0041329	Deborah Kerr	Deborah Kerr	nm0000039		Evelyn Boult
+22	1949	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056144	Come to the Stable	tt0041257	Loretta Young	Loretta Young	nm0949835		Sister Margaret
 22	1949	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056151	Pinky	tt0041746	Ethel Barrymore	Ethel Barrymore	nm0000856		Miss Em
 22	1949	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056152	Come to the Stable	tt0041257	Celeste Holm	Celeste Holm	nm0002141		Sister Scholastica
 22	1949	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056153	Come to the Stable	tt0041257	Elsa Lanchester	Elsa Lanchester	nm0006471		Miss Potts
@@ -2505,11 +2505,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 22	1949	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0056163	Sands of Iwo Jima	tt0041841	Harry Brown	Harry Brown	nm0113689
 22	1949	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0056160	The Stratton Story	tt0041928	Douglas Morrow	Douglas Morrow	nm0607487	True
 22	1949	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0056164	White Heat	tt0042041	Virginia Kellogg	Virginia Kellogg	nm0446132
-22	1949	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056166	All the King's Men	tt0041113	Robert Rossen	Robert Rossen	nm0744035
-22	1949	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056167	The Bicycle Thief	tt0040522	Cesare Zavattini	Cesare Zavattini	nm0953790
-22	1949	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056168	Champion	tt0041239	Carl Foreman	Carl Foreman	nm0286025
-22	1949	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056169	The Fallen Idol	tt0040338	Graham Greene	Graham Greene	nm0001294
-22	1949	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0056165	A Letter to Three Wives	tt0041587	Joseph L. Mankiewicz	Joseph L. Mankiewicz	nm0000581	True
+22	1949	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056166	All the King's Men	tt0041113	Robert Rossen	Robert Rossen	nm0744035
+22	1949	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056167	The Bicycle Thief	tt0040522	Cesare Zavattini	Cesare Zavattini	nm0953790
+22	1949	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056168	Champion	tt0041239	Carl Foreman	Carl Foreman	nm0286025
+22	1949	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056169	The Fallen Idol	tt0040338	Graham Greene	Graham Greene	nm0001294
+22	1949	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0056165	A Letter to Three Wives	tt0041587	Joseph L. Mankiewicz	Joseph L. Mankiewicz	nm0000581	True
 22	1949	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0056170	Battleground	tt0041163	Robert Pirosh	Robert Pirosh	nm0685265	True
 22	1949	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0056171	Jolson Sings Again	tt0041530	Sidney Buchman	Sidney Buchman	nm0118227
 22	1949	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0056172	Paisan	tt0038823	Alfred Hayes, Federico Fellini, Sergio Amidei, Marcello Pagliero, Roberto Rossellini	Alfred Hayes, Federico Fellini, Sergio Amidei, Marcello Pagliero, Roberto Rossellini	nm0370883,nm0000019,nm0024847,nm0656496,nm0744023
@@ -2528,21 +2528,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 22	1949	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0052270				Charles R. Daily, Steve Csillag, Paramount	?,nm0190725,co0023400	True	Editorial		To CHARLES R. DAILY, STEVE CSILLAG and the PARAMOUNT STUDIO ENGINEERING, EDITORIAL and MUSIC DEPARTMENTS for a new precision method of computing variable tempo click tracks.
 22	1949	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					International Projector Corporation		True	Projection		To the INTERNATIONAL PROJECTOR CORPORATION for a simplified and self-adjusting take-up device for projection machines.
 22	1949	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Alexander Velcoff		True	Photography		To ALEXANDER VELCOFF for the application to production of the infra-red photographic evaluator.
-23	1950	Acting	ACTOR	ACTOR	an0055057	The Magnificent Yankee	tt0042702	Louis Calhern	Louis Calhern	nm0129894		Oliver Wendell Holmes
-23	1950	Acting	ACTOR	ACTOR	an0055056	Cyrano de Bergerac	tt0042367	José Ferrer	José Ferrer	nm0001207	True	Cyrano de Bergerac
-23	1950	Acting	ACTOR	ACTOR	an0055058	Sunset Blvd.	tt0043014	William Holden	William Holden	nm0000034		Joe Gillis
-23	1950	Acting	ACTOR	ACTOR	an0055059	Harvey	tt0042546	James Stewart	James Stewart	nm0000071		Elwood P. Dowd
-23	1950	Acting	ACTOR	ACTOR	an0055060	Father of the Bride	tt0042451	Spencer Tracy	Spencer Tracy	nm0000075		Stanley T. Banks
+23	1950	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055057	The Magnificent Yankee	tt0042702	Louis Calhern	Louis Calhern	nm0129894		Oliver Wendell Holmes
+23	1950	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055056	Cyrano de Bergerac	tt0042367	José Ferrer	José Ferrer	nm0001207	True	Cyrano de Bergerac
+23	1950	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055058	Sunset Blvd.	tt0043014	William Holden	William Holden	nm0000034		Joe Gillis
+23	1950	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055059	Harvey	tt0042546	James Stewart	James Stewart	nm0000071		Elwood P. Dowd
+23	1950	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055060	Father of the Bride	tt0042451	Spencer Tracy	Spencer Tracy	nm0000075		Stanley T. Banks
 23	1950	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055067	Broken Arrow	tt0042286	Jeff Chandler	Jeff Chandler	nm0001996		Cochise
 23	1950	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055068	Mister 880	tt0042742	Edmund Gwenn	Edmund Gwenn	nm0350324		Skipper Miller
 23	1950	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055069	The Asphalt Jungle	tt0042208	Sam Jaffe	Sam Jaffe	nm0415488		Dr. Erwin Riedenschneider
 23	1950	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055066	All about Eve	tt0042192	George Sanders	George Sanders	nm0001695	True	Addison De Witt
 23	1950	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055070	Sunset Blvd.	tt0043014	Erich von Stroheim	Erich von Stroheim	nm0002233		Max Von Mayerling
-23	1950	Acting	ACTRESS	ACTRESS	an0055062	All about Eve	tt0042192	Anne Baxter	Anne Baxter	nm0000879		Eve Harrington
-23	1950	Acting	ACTRESS	ACTRESS	an0055063	All about Eve	tt0042192	Bette Davis	Bette Davis	nm0000012		Margo Channing
-23	1950	Acting	ACTRESS	ACTRESS	an0055061	Born Yesterday	tt0042276	Judy Holliday	Judy Holliday	nm0391062	True	Billie Dawn
-23	1950	Acting	ACTRESS	ACTRESS	an0055064	Caged	tt0042296	Eleanor Parker	Eleanor Parker	nm0662223		Marie Allen
-23	1950	Acting	ACTRESS	ACTRESS	an0055065	Sunset Blvd.	tt0043014	Gloria Swanson	Gloria Swanson	nm0841797		Norma Desmond
+23	1950	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055062	All about Eve	tt0042192	Anne Baxter	Anne Baxter	nm0000879		Eve Harrington
+23	1950	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055063	All about Eve	tt0042192	Bette Davis	Bette Davis	nm0000012		Margo Channing
+23	1950	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055061	Born Yesterday	tt0042276	Judy Holliday	Judy Holliday	nm0391062	True	Billie Dawn
+23	1950	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055064	Caged	tt0042296	Eleanor Parker	Eleanor Parker	nm0662223		Marie Allen
+23	1950	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055065	Sunset Blvd.	tt0043014	Gloria Swanson	Gloria Swanson	nm0841797		Norma Desmond
 23	1950	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055072	Caged	tt0042296	Hope Emerson	Hope Emerson	nm0256216		Evelyn Harper
 23	1950	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055073	All about Eve	tt0042192	Celeste Holm	Celeste Holm	nm0002141		Karen Richards
 23	1950	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055071	Harvey	tt0042546	Josephine Hull	Josephine Hull	nm0401449	True	Veta Louise Simmons
@@ -2626,11 +2626,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 23	1950	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0055084	Mystery Street	tt0042771	Leonard Spigelgass	Leonard Spigelgass	nm0818700
 23	1950	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0055081	Panic in the Streets	tt0042832	Edna Anhalt, Edward Anhalt	Edna Anhalt, Edward Anhalt	nm0030018,nm0030019	True
 23	1950	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0055085	When Willie Comes Marching Home	tt0043129	Sy Gomberg	Sy Gomberg	nm0177934
-23	1950	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0055086	All about Eve	tt0042192	Joseph L. Mankiewicz	Joseph L. Mankiewicz	nm0000581	True
-23	1950	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0055087	The Asphalt Jungle	tt0042208	Ben Maddow, John Huston	Ben Maddow, John Huston	nm0534693,nm0001379
-23	1950	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0055088	Born Yesterday	tt0042276	Albert Mannheimer	Albert Mannheimer	nm0543171
-23	1950	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0055089	Broken Arrow	tt0042286	Albert Maltz	Albert Maltz	nm0540816			NOTE: Based upon the research made by, and the board motion of, the Writers Guild of America West, the Academy, on July 3, 1991, decided to restore Albert Maltz to the screenplay credit on the 1950 film Broken Arrow. Michael Blankfort had fronted for him on the screenplay and consequently was named in the screenplay nomination. Mr. Blankfort's name was removed from the nomination.
-23	1950	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0055090	Father of the Bride	tt0042451	Frances Goodrich, Albert Hackett	Frances Goodrich, Albert Hackett	nm0329304,nm0352443
+23	1950	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0055086	All about Eve	tt0042192	Joseph L. Mankiewicz	Joseph L. Mankiewicz	nm0000581	True
+23	1950	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0055087	The Asphalt Jungle	tt0042208	Ben Maddow, John Huston	Ben Maddow, John Huston	nm0534693,nm0001379
+23	1950	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0055088	Born Yesterday	tt0042276	Albert Mannheimer	Albert Mannheimer	nm0543171
+23	1950	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0055089	Broken Arrow	tt0042286	Albert Maltz	Albert Maltz	nm0540816			NOTE: Based upon the research made by, and the board motion of, the Writers Guild of America West, the Academy, on July 3, 1991, decided to restore Albert Maltz to the screenplay credit on the 1950 film Broken Arrow. Michael Blankfort had fronted for him on the screenplay and consequently was named in the screenplay nomination. Mr. Blankfort's name was removed from the nomination.
+23	1950	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0055090	Father of the Bride	tt0042451	Frances Goodrich, Albert Hackett	Frances Goodrich, Albert Hackett	nm0329304,nm0352443
 23	1950	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0055092	Adam's Rib	tt0041090	Ruth Gordon, Garson Kanin	Ruth Gordon, Garson Kanin	nm0002106,nm0437717
 23	1950	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0055093	Caged	tt0042296	Virginia Kellogg, Bernard C. Schoenfeld	Virginia Kellogg, Bernard C. Schoenfeld	nm0446132,nm0774441
 23	1950	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0055094	The Men	tt0042727	Carl Foreman	Carl Foreman	nm0286025
@@ -2643,21 +2643,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 23	1950	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0055867				James B. Gordon, 20Th Century-Fox	nm0330286,co0028775	True	Laboratory		To JAMES B. GORDON and the 20TH CENTURY-FOX STUDIO CAMERA DEPARTMENT for the design and development of a multiple image film viewer.
 23	1950	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0055868				John Paul Livadary, Floyd Campbell, L. W. Russell, Columbia	nm0515093,?,?,co0050868	True	Sound		To JOHN PAUL LIVADARY, FLOYD CAMPBELL, L. W. RUSSELL and the COLUMBIA STUDIO SOUND DEPARTMENT for the development of a multi-track magnetic re-recording system.
 23	1950	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0055869				Loren L. Ryder, Paramount	nm0753122,co0023400	True	Sound		To LOREN L. RYDER and the PARAMOUNT STUDIO SOUND DEPARTMENT for the first studio-wide application of magnetic sound recording to motion picture production.
-24	1951	Acting	ACTOR	ACTOR	an0050655	The African Queen	tt0043265	Humphrey Bogart	Humphrey Bogart	nm0000007	True	Charlie Allnut
-24	1951	Acting	ACTOR	ACTOR	an0050656	A Streetcar Named Desire	tt0044081	Marlon Brando	Marlon Brando	nm0000008		Stanley Kowalski
-24	1951	Acting	ACTOR	ACTOR	an0050657	A Place in the Sun	tt0043924	Montgomery Clift	Montgomery Clift	nm0001050		George Eastman
-24	1951	Acting	ACTOR	ACTOR	an0050658	Bright Victory	tt0043361	Arthur Kennedy	Arthur Kennedy	nm0447913		Larry Levins
-24	1951	Acting	ACTOR	ACTOR	an0050659	Death of a Salesman	tt0043458	Fredric March	Fredric March	nm0545298		Willy Loman
+24	1951	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050655	The African Queen	tt0043265	Humphrey Bogart	Humphrey Bogart	nm0000007	True	Charlie Allnut
+24	1951	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050656	A Streetcar Named Desire	tt0044081	Marlon Brando	Marlon Brando	nm0000008		Stanley Kowalski
+24	1951	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050657	A Place in the Sun	tt0043924	Montgomery Clift	Montgomery Clift	nm0001050		George Eastman
+24	1951	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050658	Bright Victory	tt0043361	Arthur Kennedy	Arthur Kennedy	nm0447913		Larry Levins
+24	1951	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050659	Death of a Salesman	tt0043458	Fredric March	Fredric March	nm0545298		Willy Loman
 24	1951	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050666	Quo Vadis	tt0043949	Leo Genn	Leo Genn	nm0312890		Petronius
 24	1951	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050667	Death of a Salesman	tt0043458	Kevin McCarthy	Kevin McCarthy	nm0002994		Biff Loman
 24	1951	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050665	A Streetcar Named Desire	tt0044081	Karl Malden	Karl Malden	nm0001500	True	Mitch
 24	1951	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050668	Quo Vadis	tt0043949	Peter Ustinov	Peter Ustinov	nm0001811		Nero
 24	1951	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050669	Come Fill the Cup	tt0043424	Gig Young	Gig Young	nm0949574		Boyd Copeland
-24	1951	Acting	ACTRESS	ACTRESS	an0050661	The African Queen	tt0043265	Katharine Hepburn	Katharine Hepburn	nm0000031		Rose Sayer
-24	1951	Acting	ACTRESS	ACTRESS	an0050660	A Streetcar Named Desire	tt0044081	Vivien Leigh	Vivien Leigh	nm0000046	True	Blanche DuBois
-24	1951	Acting	ACTRESS	ACTRESS	an0050662	Detective Story	tt0043465	Eleanor Parker	Eleanor Parker	nm0662223		Mary McLeod
-24	1951	Acting	ACTRESS	ACTRESS	an0050663	A Place in the Sun	tt0043924	Shelley Winters	Shelley Winters	nm0001859		Alice Tripp
-24	1951	Acting	ACTRESS	ACTRESS	an0050664	The Blue Veil	tt0043350	Jane Wyman	Jane Wyman	nm0943837		Louise Mason
+24	1951	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050661	The African Queen	tt0043265	Katharine Hepburn	Katharine Hepburn	nm0000031		Rose Sayer
+24	1951	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050660	A Streetcar Named Desire	tt0044081	Vivien Leigh	Vivien Leigh	nm0000046	True	Blanche DuBois
+24	1951	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050662	Detective Story	tt0043465	Eleanor Parker	Eleanor Parker	nm0662223		Mary McLeod
+24	1951	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050663	A Place in the Sun	tt0043924	Shelley Winters	Shelley Winters	nm0001859		Alice Tripp
+24	1951	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050664	The Blue Veil	tt0043350	Jane Wyman	Jane Wyman	nm0943837		Louise Mason
 24	1951	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050671	The Blue Veil	tt0043350	Joan Blondell	Joan Blondell	nm0000951		Annie Rawlins
 24	1951	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050672	Death of a Salesman	tt0043458	Mildred Dunnock	Mildred Dunnock	nm0242972		Linda Loman
 24	1951	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050673	Detective Story	tt0043465	Lee Grant	Lee Grant	nm0335519		A Shoplifter
@@ -2748,11 +2748,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 24	1951	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050683	Here Comes the Groom	tt0043633	Robert Riskin, Liam O'Brien	Robert Riskin, Liam O'Brien	nm0728307,nm0639676
 24	1951	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050680	Seven Days to Noon	tt0042949	Paul Dehn, James Bernard	Paul Dehn, James Bernard	nm0214989,nm0002302	True
 24	1951	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050684	Teresa	tt0044112	Alfred Hayes, Stewart Stern	Alfred Hayes, Stewart Stern	nm0370883,nm0827856
-24	1951	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050686	The African Queen	tt0043265	James Agee, John Huston	James Agee, John Huston	nm0012938,nm0001379
-24	1951	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050687	Detective Story	tt0043465	Philip Yordan, Robert Wyler	Philip Yordan, Robert Wyler	nm0948634,nm0943753
-24	1951	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050688	La Ronde	tt0042906	Max Ophuls, Jacques Natanson	Max Ophuls, Jacques Natanson	nm0649097,nm0622148
-24	1951	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050685	A Place in the Sun	tt0043924	Michael Wilson, Harry Brown	Michael Wilson, Harry Brown	nm0933858,nm0113689	True
-24	1951	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050689	A Streetcar Named Desire	tt0044081	Tennessee Williams	Tennessee Williams	nm0931783
+24	1951	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050686	The African Queen	tt0043265	James Agee, John Huston	James Agee, John Huston	nm0012938,nm0001379
+24	1951	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050687	Detective Story	tt0043465	Philip Yordan, Robert Wyler	Philip Yordan, Robert Wyler	nm0948634,nm0943753
+24	1951	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050688	La Ronde	tt0042906	Max Ophuls, Jacques Natanson	Max Ophuls, Jacques Natanson	nm0649097,nm0622148
+24	1951	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050685	A Place in the Sun	tt0043924	Michael Wilson, Harry Brown	Michael Wilson, Harry Brown	nm0933858,nm0113689	True
+24	1951	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050689	A Streetcar Named Desire	tt0044081	Tennessee Williams	Tennessee Williams	nm0931783
 24	1951	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0050690	An American in Paris	tt0043278	Alan Jay Lerner	Alan Jay Lerner	nm0503585	True
 24	1951	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0050691	The Big Carnival	tt0043338	Billy Wilder, Lesser Samuels, Walter Newman	Billy Wilder, Lesser Samuels, Walter Newman	nm0000697,nm0760488,nm0628305
 24	1951	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0050692	David and Bathsheba	tt0043455	Philip Dunne	Philip Dunne	nm0242897
@@ -2769,21 +2769,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 24	1951	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0052194				Glen Robinson, Metro-Goldwyn-Mayer	nm0732656,co0007143	True	Stage Operations		To GLEN ROBINSON and the METRO-GOLDWYN-MAYER STUDIO CONSTRUCTION DEPARTMENT for the development of a new music wire and cable cutter.
 24	1951	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0052195				Jack Gaylord, Metro-Goldwyn-Mayer	nm2182856,co0007143	True	Stage Operations		To JACK GAYLORD and the METRO-GOLDWYN-MAYER STUDIO CONSTRUCTION DEPARTMENT for the development of balsa falling snow.
 24	1951	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					CARLOS RIVAS		True	Editorial		To CARLOS RIVAS of Metro-Goldwyn-Mayer Studio for the development of an automatic magnetic film splicer.
-25	1952	Acting	ACTOR	ACTOR	an0049253	Viva Zapata!	tt0045296	Marlon Brando	Marlon Brando	nm0000008		Emiliano Zapata
-25	1952	Acting	ACTOR	ACTOR	an0049252	High Noon	tt0044706	Gary Cooper	Gary Cooper	nm0000011	True	Will Kane
-25	1952	Acting	ACTOR	ACTOR	an0049254	The Bad and the Beautiful	tt0044391	Kirk Douglas	Kirk Douglas	nm0000018		Jonathan Shields
-25	1952	Acting	ACTOR	ACTOR	an0049255	Moulin Rouge	tt0044926	José Ferrer	José Ferrer	nm0001207		Toulouse-Lautrec
-25	1952	Acting	ACTOR	ACTOR	an0049256	The Lavender Hill Mob	tt0044829	Alec Guinness	Alec Guinness	nm0000027		Holland
+25	1952	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049253	Viva Zapata!	tt0045296	Marlon Brando	Marlon Brando	nm0000008		Emiliano Zapata
+25	1952	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049252	High Noon	tt0044706	Gary Cooper	Gary Cooper	nm0000011	True	Will Kane
+25	1952	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049254	The Bad and the Beautiful	tt0044391	Kirk Douglas	Kirk Douglas	nm0000018		Jonathan Shields
+25	1952	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049255	Moulin Rouge	tt0044926	José Ferrer	José Ferrer	nm0001207		Toulouse-Lautrec
+25	1952	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0049256	The Lavender Hill Mob	tt0044829	Alec Guinness	Alec Guinness	nm0000027		Holland
 25	1952	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049263	My Cousin Rachel	tt0044937	Richard Burton	Richard Burton	nm0000009		Philip Ashley
 25	1952	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049264	The Big Sky	tt0044419	Arthur Hunnicutt	Arthur Hunnicutt	nm0402277		Zeb Callaway
 25	1952	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049265	The Quiet Man	tt0045061	Victor McLaglen	Victor McLaglen	nm0572142		Red Will Danaher
 25	1952	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049266	Sudden Fear	tt0045205	Jack Palance	Jack Palance	nm0001588		Lester Blaine
 25	1952	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0049262	Viva Zapata!	tt0045296	Anthony Quinn	Anthony Quinn	nm0000063	True	Eufemio Zapata
-25	1952	Acting	ACTRESS	ACTRESS	an0049257	Come Back, Little Sheba	tt0044509	Shirley Booth	Shirley Booth	nm0095804	True	Lola Delaney
-25	1952	Acting	ACTRESS	ACTRESS	an0049258	Sudden Fear	tt0045205	Joan Crawford	Joan Crawford	nm0001076		Myra Hudson
-25	1952	Acting	ACTRESS	ACTRESS	an0049259	The Star	tt0045186	Bette Davis	Bette Davis	nm0000012		Margaret Elliot
-25	1952	Acting	ACTRESS	ACTRESS	an0049260	The Member of the Wedding	tt0044896	Julie Harris	Julie Harris	nm0364915		Frankie Addams
-25	1952	Acting	ACTRESS	ACTRESS	an0049261	With a Song in My Heart	tt0045333	Susan Hayward	Susan Hayward	nm0001333		Jane Froman
+25	1952	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049257	Come Back, Little Sheba	tt0044509	Shirley Booth	Shirley Booth	nm0095804	True	Lola Delaney
+25	1952	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049258	Sudden Fear	tt0045205	Joan Crawford	Joan Crawford	nm0001076		Myra Hudson
+25	1952	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049259	The Star	tt0045186	Bette Davis	Bette Davis	nm0000012		Margaret Elliot
+25	1952	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049260	The Member of the Wedding	tt0044896	Julie Harris	Julie Harris	nm0364915		Frankie Addams
+25	1952	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0049261	With a Song in My Heart	tt0045333	Susan Hayward	Susan Hayward	nm0001333		Jane Froman
 25	1952	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049267	The Bad and the Beautiful	tt0044391	Gloria Grahame	Gloria Grahame	nm0002108	True	Rosemary Bartlow
 25	1952	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049268	Singin' in the Rain	tt0045152	Jean Hagen	Jean Hagen	nm0353405		Lina Lamont
 25	1952	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0049269	Moulin Rouge	tt0044926	Colette Marchand	Colette Marchand	nm0545376		Marie Charlet
@@ -2881,11 +2881,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 25	1952	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0049279	The Narrow Margin	tt0044954	Martin Goldsmith, Jack Leonard	Martin Goldsmith, Jack Leonard	nm0326107,nm0502649
 25	1952	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0049280	The Pride of St. Louis	tt0045049	Guy Trosper	Guy Trosper	nm0873613
 25	1952	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0049281	The Sniper	tt0045161	Edna Anhalt, Edward Anhalt	Edna Anhalt, Edward Anhalt	nm0030018,nm0030019
-25	1952	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049282	The Bad and the Beautiful	tt0044391	Charles Schnee	Charles Schnee	nm0773660	True
-25	1952	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049283	Five Fingers	tt0044314	Michael Wilson	Michael Wilson	nm0933858
-25	1952	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049284	High Noon	tt0044706	Carl Foreman	Carl Foreman	nm0286025
-25	1952	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049285	The Man in the White Suit	tt0044876	Roger MacDougall, John Dighton, Alexander Mackendrick	Roger MacDougall, John Dighton, Alexander Mackendrick	nm0532032,nm0226538,nm0533241
-25	1952	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0049286	The Quiet Man	tt0045061	Frank S. Nugent	Frank S. Nugent	nm0637793
+25	1952	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049282	The Bad and the Beautiful	tt0044391	Charles Schnee	Charles Schnee	nm0773660	True
+25	1952	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049283	Five Fingers	tt0044314	Michael Wilson	Michael Wilson	nm0933858
+25	1952	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049284	High Noon	tt0044706	Carl Foreman	Carl Foreman	nm0286025
+25	1952	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049285	The Man in the White Suit	tt0044876	Roger MacDougall, John Dighton, Alexander Mackendrick	Roger MacDougall, John Dighton, Alexander Mackendrick	nm0532032,nm0226538,nm0533241
+25	1952	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0049286	The Quiet Man	tt0045061	Frank S. Nugent	Frank S. Nugent	nm0637793
 25	1952	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0049288	The Atomic City	tt0044382	Sydney Boehm	Sydney Boehm	nm0091213
 25	1952	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0049289	Breaking the Sound Barrier	tt0044446	Terence Rattigan	Terence Rattigan	nm0711905
 25	1952	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0049287	The Lavender Hill Mob	tt0044829	T. E. B. Clarke	T. E. B. Clarke	nm0165021	True
@@ -2906,21 +2906,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 25	1952	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Photo Research Corporation		True	Photography		To PHOTO RESEARCH CORPORATION for creating the Spectra color temperature meter.
 25	1952	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Gustav Jirouch		True	Editorial		To GUSTAV JIROUCH for the design of the Robot automatic film splicer.
 25	1952	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					CARLOS RIVAS		True	Sound		To CARLOS RIVAS of Metro-Goldwyn-Mayer Studio for the development of a sound reproducer for magnetic film.
-26	1953	Acting	ACTOR	ACTOR	an0050532	Julius Caesar	tt0045943	Marlon Brando	Marlon Brando	nm0000008		Marc Antony
-26	1953	Acting	ACTOR	ACTOR	an0050533	The Robe	tt0046247	Richard Burton	Richard Burton	nm0000009		Marcellus Gallio
-26	1953	Acting	ACTOR	ACTOR	an0050534	From Here to Eternity	tt0045793	Montgomery Clift	Montgomery Clift	nm0001050		Robert E. Lee Prewitt
-26	1953	Acting	ACTOR	ACTOR	an0050531	Stalag 17	tt0046359	William Holden	William Holden	nm0000034	True	Sefton
-26	1953	Acting	ACTOR	ACTOR	an0050535	From Here to Eternity	tt0045793	Burt Lancaster	Burt Lancaster	nm0000044		Sgt. Milton Warden
+26	1953	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050532	Julius Caesar	tt0045943	Marlon Brando	Marlon Brando	nm0000008		Marc Antony
+26	1953	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050533	The Robe	tt0046247	Richard Burton	Richard Burton	nm0000009		Marcellus Gallio
+26	1953	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050534	From Here to Eternity	tt0045793	Montgomery Clift	Montgomery Clift	nm0001050		Robert E. Lee Prewitt
+26	1953	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050531	Stalag 17	tt0046359	William Holden	William Holden	nm0000034	True	Sefton
+26	1953	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050535	From Here to Eternity	tt0045793	Burt Lancaster	Burt Lancaster	nm0000044		Sgt. Milton Warden
 26	1953	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050542	Roman Holiday	tt0046250	Eddie Albert	Eddie Albert	nm0000734		Irving Radovich
 26	1953	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050543	Shane	tt0046303	Brandon De Wilde	Brandon De Wilde	nm0001121		Joey Starrett
 26	1953	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050544	Shane	tt0046303	Jack Palance	Jack Palance	nm0001588		Wilson
 26	1953	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050541	From Here to Eternity	tt0045793	Frank Sinatra	Frank Sinatra	nm0000069	True	Angelo Maggio
 26	1953	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050545	Stalag 17	tt0046359	Robert Strauss	Robert Strauss	nm0833865		Stosh/'Animal'
-26	1953	Acting	ACTRESS	ACTRESS	an0050537	Lili	tt0046000	Leslie Caron	Leslie Caron	nm0001989		Lili Daurier
-26	1953	Acting	ACTRESS	ACTRESS	an0050538	Mogambo	tt0046085	Ava Gardner	Ava Gardner	nm0001257		Eloise 'Honey Bear' Kelly
-26	1953	Acting	ACTRESS	ACTRESS	an0050536	Roman Holiday	tt0046250	Audrey Hepburn	Audrey Hepburn	nm0000030	True	Princess Anne
-26	1953	Acting	ACTRESS	ACTRESS	an0050539	From Here to Eternity	tt0045793	Deborah Kerr	Deborah Kerr	nm0000039		Karen Holmes
-26	1953	Acting	ACTRESS	ACTRESS	an0050540	The Moon Is Blue	tt0046094	Maggie McNamara	Maggie McNamara	nm0573704		Patty O'Neill
+26	1953	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050537	Lili	tt0046000	Leslie Caron	Leslie Caron	nm0001989		Lili Daurier
+26	1953	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050538	Mogambo	tt0046085	Ava Gardner	Ava Gardner	nm0001257		Eloise 'Honey Bear' Kelly
+26	1953	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050536	Roman Holiday	tt0046250	Audrey Hepburn	Audrey Hepburn	nm0000030	True	Princess Anne
+26	1953	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050539	From Here to Eternity	tt0045793	Deborah Kerr	Deborah Kerr	nm0000039		Karen Holmes
+26	1953	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050540	The Moon Is Blue	tt0046094	Maggie McNamara	Maggie McNamara	nm0573704		Patty O'Neill
 26	1953	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050547	Mogambo	tt0046085	Grace Kelly	Grace Kelly	nm0000038		Linda Nordley
 26	1953	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050548	Hondo	tt0045883	Geraldine Page	Geraldine Page	nm0656183		Angie Lowe
 26	1953	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050549	Torch Song	tt0046446	Marjorie Rambeau	Marjorie Rambeau	nm0708081		Mrs. Stewart
@@ -3020,11 +3020,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 26	1953	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050559	Hondo	tt0045883	Louis L'Amour	Louis L'Amour	nm0478263			NOTE: THIS IS NOT AN OFFICIAL NOMINATION. Originally announced on February 15, 1954 as a nominee in this category. On February 17, 1954, letters from the producer and the nominee questioned its inclusion in the (original) motion picture story category, as it was based on the short story, \"The Gift of Cochise,\" by the nominee, published in Collier's magazine on July 5, 1952. By waiver, the title of the short story was not included in the film's credits. The nomination was withdrawn, and only four titles were included on the final ballot.
 26	1953	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050560	Little Fugitive	tt0046004	Ray Ashley, Morris Engel, Ruth Orkin	Ray Ashley, Morris Engel, Ruth Orkin	nm0039107,nm0257129,nm0649907
 26	1953	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0050556	Roman Holiday	tt0046250	Dalton Trumbo	Dalton Trumbo	nm0874308	True		NOTE: The screen credit and award were originally credited to Ian McLellan Hunter, who was a \"front\" for Dalton Trumbo. On December 15, 1992, the Academy's Board of Governors voted to change the records and award Mr. Trumbo with the achievement. Ian McLellan Hunter's name was removed from the Motion Picture Story category. The Oscar was posthumously presented to Trumbo's widow on May 10, 1993.
-26	1953	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050562	The Cruel Sea	tt0045659	Eric Ambler	Eric Ambler	nm0001907
-26	1953	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050561	From Here to Eternity	tt0045793	Daniel Taradash	Daniel Taradash	nm0850168	True
-26	1953	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050563	Lili	tt0046000	Helen Deutsch	Helen Deutsch	nm0222079
-26	1953	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050564	Roman Holiday	tt0046250	Ian McLellan Hunter, John Dighton	Ian McLellan Hunter, John Dighton	nm0402848,nm0226538
-26	1953	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0050565	Shane	tt0046303	A. B. Guthrie, Jr.	A. B. Guthrie Jr.	nm0349238
+26	1953	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050562	The Cruel Sea	tt0045659	Eric Ambler	Eric Ambler	nm0001907
+26	1953	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050561	From Here to Eternity	tt0045793	Daniel Taradash	Daniel Taradash	nm0850168	True
+26	1953	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050563	Lili	tt0046000	Helen Deutsch	Helen Deutsch	nm0222079
+26	1953	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050564	Roman Holiday	tt0046250	Ian McLellan Hunter, John Dighton	Ian McLellan Hunter, John Dighton	nm0402848,nm0226538
+26	1953	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0050565	Shane	tt0046303	A. B. Guthrie, Jr.	A. B. Guthrie Jr.	nm0349238
 26	1953	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0050567	The Band Wagon	tt0045537	Betty Comden, Adolph Green	Betty Comden, Adolph Green	nm0173679,nm0337582
 26	1953	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0050568	The Desert Rats	tt0045679	Richard Murphy	Richard Murphy	nm0614645
 26	1953	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0050569	The Naked Spur	tt0044953	Sam Rolfe, Harold Jack Bloom	Sam Rolfe, Harold Jack Bloom	nm0738222,nm0089169
@@ -3039,21 +3039,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 26	1953	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class I)	SCIENTIFIC OR TECHNICAL AWARD (Class I)	an0053182				Fred Waller	nm0909044	True	Systems		To FRED WALLER for designing and developing the multiple photographic and projection systems which culminated in Cinerama.
 26	1953	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Reeves Soundcraft Corporation		True	Sound		To REEVES SOUNDCRAFT CORPORATION for their development of a process of applying stripes of magnetic oxide to motion picture film for sound recording and reproduction.
 26	1953	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Westrex Corporation		True	Editorial		To WESTREX CORPORATION for the design and construction of a new film editing machine.
-27	1954	Acting	ACTOR	ACTOR	an0054659	The Caine Mutiny	tt0046816	Humphrey Bogart	Humphrey Bogart	nm0000007		Captain Queeg
-27	1954	Acting	ACTOR	ACTOR	an0054658	On the Waterfront	tt0047296	Marlon Brando	Marlon Brando	nm0000008	True	Terry Malloy
-27	1954	Acting	ACTOR	ACTOR	an0054660	The Country Girl	tt0046874	Bing Crosby	Bing Crosby	nm0001078		Frank Elgin
-27	1954	Acting	ACTOR	ACTOR	an0054661	A Star Is Born	tt0047522	James Mason	James Mason	nm0000051		Norman Maine/Alfred Hinkel
-27	1954	Acting	ACTOR	ACTOR	an0054662	Adventures of Robinson Crusoe	tt0044386	Dan O'Herlihy	Dan O'Herlihy	nm0641397		Robinson Crusoe
+27	1954	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054659	The Caine Mutiny	tt0046816	Humphrey Bogart	Humphrey Bogart	nm0000007		Captain Queeg
+27	1954	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054658	On the Waterfront	tt0047296	Marlon Brando	Marlon Brando	nm0000008	True	Terry Malloy
+27	1954	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054660	The Country Girl	tt0046874	Bing Crosby	Bing Crosby	nm0001078		Frank Elgin
+27	1954	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054661	A Star Is Born	tt0047522	James Mason	James Mason	nm0000051		Norman Maine/Alfred Hinkel
+27	1954	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054662	Adventures of Robinson Crusoe	tt0044386	Dan O'Herlihy	Dan O'Herlihy	nm0641397		Robinson Crusoe
 27	1954	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054669	On the Waterfront	tt0047296	Lee J. Cobb	Lee J. Cobb	nm0002011		Johnny Friendly
 27	1954	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054670	On the Waterfront	tt0047296	Karl Malden	Karl Malden	nm0001500		Father Barry
 27	1954	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054668	The Barefoot Contessa	tt0046754	Edmond O'Brien	Edmond O'Brien	nm0639529	True	Oscar Muldoon
 27	1954	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054671	On the Waterfront	tt0047296	Rod Steiger	Rod Steiger	nm0001768		Charles Malloy
 27	1954	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054672	The Caine Mutiny	tt0046816	Tom Tully	Tom Tully	nm0876451		Captain DeVriess
-27	1954	Acting	ACTRESS	ACTRESS	an0054664	Carmen Jones	tt0046828	Dorothy Dandridge	Dorothy Dandridge	nm0199268		Carmen Jones
-27	1954	Acting	ACTRESS	ACTRESS	an0054665	A Star Is Born	tt0047522	Judy Garland	Judy Garland	nm0000023		Esther Blodgett/Vicki Lester
-27	1954	Acting	ACTRESS	ACTRESS	an0054666	Sabrina	tt0047437	Audrey Hepburn	Audrey Hepburn	nm0000030		Sabrina Fairchild
-27	1954	Acting	ACTRESS	ACTRESS	an0054663	The Country Girl	tt0046874	Grace Kelly	Grace Kelly	nm0000038	True	Georgie Elgin
-27	1954	Acting	ACTRESS	ACTRESS	an0054667	Magnificent Obsession	tt0047203	Jane Wyman	Jane Wyman	nm0943837		Helen Phillips
+27	1954	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054664	Carmen Jones	tt0046828	Dorothy Dandridge	Dorothy Dandridge	nm0199268		Carmen Jones
+27	1954	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054665	A Star Is Born	tt0047522	Judy Garland	Judy Garland	nm0000023		Esther Blodgett/Vicki Lester
+27	1954	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054666	Sabrina	tt0047437	Audrey Hepburn	Audrey Hepburn	nm0000030		Sabrina Fairchild
+27	1954	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054663	The Country Girl	tt0046874	Grace Kelly	Grace Kelly	nm0000038	True	Georgie Elgin
+27	1954	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054667	Magnificent Obsession	tt0047203	Jane Wyman	Jane Wyman	nm0943837		Helen Phillips
 27	1954	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054674	Executive Suite	tt0046963	Nina Foch	Nina Foch	nm0001225		Erica Martin
 27	1954	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054675	Broken Lance	tt0046808	Katy Jurado	Katy Jurado	nm0432827		Senora Devereaux
 27	1954	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054673	On the Waterfront	tt0047296	Eva Marie Saint	Eva Marie Saint	nm0001693	True	Edie Doyle
@@ -3149,11 +3149,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 27	1954	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0054685	Forbidden Games	tt0043686	François Boyer	François Boyer	nm0102030
 27	1954	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0054686	Night People	tt0047279	Jed Harris, Tom Reed	Jed Harris, Tom Reed	nm0364824,nm0715723
 27	1954	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0054687	There's No Business Like Show Business	tt0047574	Lamar Trotti	Lamar Trotti	nm0873707
-27	1954	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054689	The Caine Mutiny	tt0046816	Stanley Roberts	Stanley Roberts	nm0731592
-27	1954	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054688	The Country Girl	tt0046874	George Seaton	George Seaton	nm0780833	True
-27	1954	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054690	Rear Window	tt0047396	John Michael Hayes	John Michael Hayes	nm0371088
-27	1954	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054691	Sabrina	tt0047437	Billy Wilder, Samuel Taylor, Ernest Lehman	Billy Wilder, Samuel Taylor, Ernest Lehman	nm0000697,nm0853138,nm0499626
-27	1954	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054692	Seven Brides for Seven Brothers	tt0047472	Albert Hackett, Frances Goodrich, Dorothy Kingsley	Albert Hackett, Frances Goodrich, Dorothy Kingsley	nm0352443,nm0329304,nm0455510
+27	1954	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054689	The Caine Mutiny	tt0046816	Stanley Roberts	Stanley Roberts	nm0731592
+27	1954	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054688	The Country Girl	tt0046874	George Seaton	George Seaton	nm0780833	True
+27	1954	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054690	Rear Window	tt0047396	John Michael Hayes	John Michael Hayes	nm0371088
+27	1954	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054691	Sabrina	tt0047437	Billy Wilder, Samuel Taylor, Ernest Lehman	Billy Wilder, Samuel Taylor, Ernest Lehman	nm0000697,nm0853138,nm0499626
+27	1954	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054692	Seven Brides for Seven Brothers	tt0047472	Albert Hackett, Frances Goodrich, Dorothy Kingsley	Albert Hackett, Frances Goodrich, Dorothy Kingsley	nm0352443,nm0329304,nm0455510
 27	1954	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0054694	The Barefoot Contessa	tt0046754	Joseph L. Mankiewicz	Joseph L. Mankiewicz	nm0000581
 27	1954	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0054695	Genevieve	tt0045808	William Rose	William Rose	nm0741740
 27	1954	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0054696	The Glenn Miller Story	tt0047030	Valentine Davies, Oscar Brodney	Valentine Davies, Oscar Brodney	nm0204016,nm0110958
@@ -3176,21 +3176,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 27	1954	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					FRED WILSON		True	Sound		To FRED WILSON of the Samuel Goldwyn Studio Sound Department for the design of a variable multiple-band equalizer.
 27	1954	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					P.C. YOUNG		True	Projection		To P.C. YOUNG of the Metro-Goldwyn-Mayer Studio Projection Department for the practical application of a variable focal length attachment to motion picture projector lenses.
 27	1954	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0054648				FRED KNOTH, ORIEN ERNEST	nm0461397,nm0259645	True	Stage Operations		To FRED KNOTH and ORIEN ERNEST of the Universal-International Studio Technical Department for the development of a hand portable, electric, dry oil-fog machine.
-28	1955	Acting	ACTOR	ACTOR	an0054170	Marty	tt0048356	Ernest Borgnine	Ernest Borgnine	nm0000308	True	Marty Pilletti
-28	1955	Acting	ACTOR	ACTOR	an0054171	Love Me or Leave Me	tt0048317	James Cagney	James Cagney	nm0000010		Martin Snyder
-28	1955	Acting	ACTOR	ACTOR	an0054172	East of Eden	tt0048028	James Dean	James Dean	nm0000015		Cal Trask
-28	1955	Acting	ACTOR	ACTOR	an0054173	The Man with the Golden Arm	tt0048347	Frank Sinatra	Frank Sinatra	nm0000069		Frankie
-28	1955	Acting	ACTOR	ACTOR	an0054174	Bad Day at Black Rock	tt0047849	Spencer Tracy	Spencer Tracy	nm0000075		John J. Macreedy
+28	1955	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054170	Marty	tt0048356	Ernest Borgnine	Ernest Borgnine	nm0000308	True	Marty Pilletti
+28	1955	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054171	Love Me or Leave Me	tt0048317	James Cagney	James Cagney	nm0000010		Martin Snyder
+28	1955	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054172	East of Eden	tt0048028	James Dean	James Dean	nm0000015		Cal Trask
+28	1955	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054173	The Man with the Golden Arm	tt0048347	Frank Sinatra	Frank Sinatra	nm0000069		Frankie
+28	1955	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054174	Bad Day at Black Rock	tt0047849	Spencer Tracy	Spencer Tracy	nm0000075		John J. Macreedy
 28	1955	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054181	Trial	tt0048748	Arthur Kennedy	Arthur Kennedy	nm0447913		Barney Castle
 28	1955	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054180	Mister Roberts	tt0048380	Jack Lemmon	Jack Lemmon	nm0000493	True	Ensign Pulver
 28	1955	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054182	Marty	tt0048356	Joe Mantell	Joe Mantell	nm0544064		Angie
 28	1955	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054183	Rebel without a Cause	tt0048545	Sal Mineo	Sal Mineo	nm0000543		Plato
 28	1955	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054184	Picnic	tt0048491	Arthur O'Connell	Arthur O'Connell	nm0640023		Howard Bevans
-28	1955	Acting	ACTRESS	ACTRESS	an0054176	I'll Cry Tomorrow	tt0048191	Susan Hayward	Susan Hayward	nm0001333		Lillian Roth
-28	1955	Acting	ACTRESS	ACTRESS	an0054177	Summertime	tt0048673	Katharine Hepburn	Katharine Hepburn	nm0000031		Jane Hudson
-28	1955	Acting	ACTRESS	ACTRESS	an0054178	Love Is a Many-Splendored Thing	tt0048316	Jennifer Jones	Jennifer Jones	nm0428354		Han Suyin
-28	1955	Acting	ACTRESS	ACTRESS	an0054175	The Rose Tattoo	tt0048563	Anna Magnani	Anna Magnani	nm0536167	True	Serafina Della Rose
-28	1955	Acting	ACTRESS	ACTRESS	an0054179	Interrupted Melody	tt0048210	Eleanor Parker	Eleanor Parker	nm0662223		Marjorie Lawrence
+28	1955	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054176	I'll Cry Tomorrow	tt0048191	Susan Hayward	Susan Hayward	nm0001333		Lillian Roth
+28	1955	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054177	Summertime	tt0048673	Katharine Hepburn	Katharine Hepburn	nm0000031		Jane Hudson
+28	1955	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054178	Love Is a Many-Splendored Thing	tt0048316	Jennifer Jones	Jennifer Jones	nm0428354		Han Suyin
+28	1955	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054175	The Rose Tattoo	tt0048563	Anna Magnani	Anna Magnani	nm0536167	True	Serafina Della Rose
+28	1955	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054179	Interrupted Melody	tt0048210	Eleanor Parker	Eleanor Parker	nm0662223		Marjorie Lawrence
 28	1955	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054186	Marty	tt0048356	Betsy Blair	Betsy Blair	nm0086198		Clara Snyder
 28	1955	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054187	Pete Kelly's Blues	tt0048484	Peggy Lee	Peggy Lee	nm0498007		Rose Hopkins
 28	1955	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054188	The Rose Tattoo	tt0048563	Marisa Pavan	Marisa Pavan	nm0667542		Rosa Della Rose
@@ -3287,11 +3287,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 28	1955	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0054197	Rebel without a Cause	tt0048545	Nicholas Ray	Nicholas Ray	nm0712947
 28	1955	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0054198	The Sheep Has Five Legs	tt0047250	Jean Marsan, Henry Troyat, Jacques Perret, Henri Verneuil, Raoul Ploquin	Jean Marsan, Henry Troyat, Jacques Perret, Henri Verneuil, Raoul Ploquin	nm0550375,nm0873935,nm0674598,nm0894577,nm0687402
 28	1955	Writing	WRITING (Original Story)	WRITING (Motion Picture Story)	an0054199	Strategic Air Command	tt0048667	Beirne Lay, Jr.	Beirne Lay Jr.	nm0493446
-28	1955	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054201	Bad Day at Black Rock	tt0047849	Millard Kaufman	Millard Kaufman	nm0442228
-28	1955	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054202	Blackboard Jungle	tt0047885	Richard Brooks	Richard Brooks	nm0112218
-28	1955	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054203	East of Eden	tt0048028	Paul Osborn	Paul Osborn	nm0651585
-28	1955	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054204	Love Me or Leave Me	tt0048317	Daniel Fuchs, Isobel Lennart	Daniel Fuchs, Isobel Lennart	nm0297190,nm0501973
-28	1955	Writing	WRITING (Screenplay)	WRITING (Screenplay)	an0054200	Marty	tt0048356	Paddy Chayefsky	Paddy Chayefsky	nm0154665	True
+28	1955	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054201	Bad Day at Black Rock	tt0047849	Millard Kaufman	Millard Kaufman	nm0442228
+28	1955	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054202	Blackboard Jungle	tt0047885	Richard Brooks	Richard Brooks	nm0112218
+28	1955	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054203	East of Eden	tt0048028	Paul Osborn	Paul Osborn	nm0651585
+28	1955	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054204	Love Me or Leave Me	tt0048317	Daniel Fuchs, Isobel Lennart	Daniel Fuchs, Isobel Lennart	nm0297190,nm0501973
+28	1955	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay)	an0054200	Marty	tt0048356	Paddy Chayefsky	Paddy Chayefsky	nm0154665	True
 28	1955	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0054206	The Court-Martial of Billy Mitchell	tt0047956	Milton Sperling, Emmet Lavery	Milton Sperling, Emmet Lavery	nm0818328,nm0491964
 28	1955	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0054205	Interrupted Melody	tt0048210	William Ludwig, Sonya Levien	William Ludwig, Sonya Levien	nm0525067,nm0397022	True
 28	1955	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay)	an0054207	It's Always Fair Weather	tt0048216	Betty Comden, Adolph Green	Betty Comden, Adolph Green	nm0173679,nm0337582
@@ -3307,21 +3307,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 28	1955	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					DAVE ANDERSON		True	Lighting		To DAVE ANDERSON of 20th Century-Fox Studio for an improved spotlight capable of maintaining a fixed circle of light at constant intensity over varied distances.
 28	1955	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0053932				Loren L. Ryder, Charles West, Henry Fracker, Paramount Studios	nm0753122,?,?,?	True	Projection		To LOREN L. RYDER, CHARLES WEST, HENRY FRACKER and the PARAMOUNT STUDIOS for a projection film index to establish proper framing for various aspect ratios.
 28	1955	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0053933				Farciot Edouart, Hal Corl, Paramount	nm0249643,?,co0023400	True	Special Photographic		To FARCIOT EDOUART, HAL CORL and the PARAMOUNT STUDIO TRANSPARENCY DEPARTMENT for an improved dual stereopticon background projector.
-29	1956	Acting	ACTOR	ACTOR	an0051484	The King and I	tt0049408	Yul Brynner	Yul Brynner	nm0000989	True	The King
-29	1956	Acting	ACTOR	ACTOR	an0051485	Giant	tt0049261	James Dean	James Dean	nm0000015		Jett Rink
-29	1956	Acting	ACTOR	ACTOR	an0051486	Lust for Life	tt0049456	Kirk Douglas	Kirk Douglas	nm0000018		Vincent Van Gogh
-29	1956	Acting	ACTOR	ACTOR	an0051487	Giant	tt0049261	Rock Hudson	Rock Hudson	nm0001369		Bick Benedict
-29	1956	Acting	ACTOR	ACTOR	an0051488	Richard III	tt0049674	Sir Laurence Olivier	Sir Laurence Olivier	nm0000059		Richard III
+29	1956	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051484	The King and I	tt0049408	Yul Brynner	Yul Brynner	nm0000989	True	The King
+29	1956	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051485	Giant	tt0049261	James Dean	James Dean	nm0000015		Jett Rink
+29	1956	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051486	Lust for Life	tt0049456	Kirk Douglas	Kirk Douglas	nm0000018		Vincent Van Gogh
+29	1956	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051487	Giant	tt0049261	Rock Hudson	Rock Hudson	nm0001369		Bick Benedict
+29	1956	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051488	Richard III	tt0049674	Sir Laurence Olivier	Sir Laurence Olivier	nm0000059		Richard III
 29	1956	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051495	Bus Stop	tt0049038	Don Murray	Don Murray	nm0614916		Bo
 29	1956	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051496	Friendly Persuasion	tt0049233	Anthony Perkins	Anthony Perkins	nm0000578		Josh Birdwell
 29	1956	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051494	Lust for Life	tt0049456	Anthony Quinn	Anthony Quinn	nm0000063	True	Paul Gauguin
 29	1956	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051497	The Bold and the Brave	tt0049022	Mickey Rooney	Mickey Rooney	nm0001682		Dooley
 29	1956	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051498	Written on the Wind	tt0049966	Robert Stack	Robert Stack	nm0821041		Kyle Hadley
-29	1956	Acting	ACTRESS	ACTRESS	an0051490	Baby Doll	tt0048973	Carroll Baker	Carroll Baker	nm0004647		Baby Doll
-29	1956	Acting	ACTRESS	ACTRESS	an0051489	Anastasia	tt0048947	Ingrid Bergman	Ingrid Bergman	nm0000006	True	The Woman
-29	1956	Acting	ACTRESS	ACTRESS	an0051491	The Rainmaker	tt0049653	Katharine Hepburn	Katharine Hepburn	nm0000031		Lizzie Curry
-29	1956	Acting	ACTRESS	ACTRESS	an0051492	The Bad Seed	tt0048977	Nancy Kelly	Nancy Kelly	nm0446715		Christine Penmark
-29	1956	Acting	ACTRESS	ACTRESS	an0051493	The King and I	tt0049408	Deborah Kerr	Deborah Kerr	nm0000039		Anna
+29	1956	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051490	Baby Doll	tt0048973	Carroll Baker	Carroll Baker	nm0004647		Baby Doll
+29	1956	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051489	Anastasia	tt0048947	Ingrid Bergman	Ingrid Bergman	nm0000006	True	The Woman
+29	1956	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051491	The Rainmaker	tt0049653	Katharine Hepburn	Katharine Hepburn	nm0000031		Lizzie Curry
+29	1956	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051492	The Bad Seed	tt0048977	Nancy Kelly	Nancy Kelly	nm0446715		Christine Penmark
+29	1956	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051493	The King and I	tt0049408	Deborah Kerr	Deborah Kerr	nm0000039		Anna
 29	1956	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051500	Baby Doll	tt0048973	Mildred Dunnock	Mildred Dunnock	nm0242972		Aunt Rose Comfort
 29	1956	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051501	The Bad Seed	tt0048977	Eileen Heckart	Eileen Heckart	nm0373012		Mrs. Daigle
 29	1956	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051502	Giant	tt0049261	Mercedes McCambridge	Mercedes McCambridge	nm0564790		Luz Benedict
@@ -3441,21 +3441,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 29	1956	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					ROY C. STEWART AND SONS, DR. C.R. DAILY, PARAMOUNT PICTURES CORP.		True	Special Photographic		To ROY C. STEWART AND SONS of Stewart-Trans Lux Corp., DR. C.R. DAILY and the TRANSPARENCY DEPARTMENT OF PARAMOUNT PICTURES CORP. for the engineering and development of the HiTrans and Para-HiTrans rear projection screens.
 29	1956	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Metro-Goldwyn-Mayer Studio		True	Stage Operations		To the CONSTRUCTION DEPARTMENT OF METRO-GOLDWYN-MAYER STUDIO for a new hand-portable fog machine.
 29	1956	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0049720				Daniel J. Bloomberg, John Pond, William Wade, Republic Studio	nm0089253,?,?,?	True	Photography		To DANIEL J. BLOOMBERG, JOHN POND, WILLIAM WADE and the ENGINEERING AND CAMERA DEPARTMENTS OF REPUBLIC STUDIO for the Naturama adaptation to the Mitchell camera.
-30	1957	Acting	ACTOR	ACTOR	an0053515	Sayonara	tt0050933	Marlon Brando	Marlon Brando	nm0000008		Major Lloyd Gruver
-30	1957	Acting	ACTOR	ACTOR	an0053516	A Hatful of Rain	tt0050487	Anthony Franciosa	Anthony Franciosa	nm0290047		Polo
-30	1957	Acting	ACTOR	ACTOR	an0053514	The Bridge on the River Kwai	tt0050212	Alec Guinness	Alec Guinness	nm0000027	True	Colonel Nicholson
-30	1957	Acting	ACTOR	ACTOR	an0053517	Witness for the Prosecution	tt0051201	Charles Laughton	Charles Laughton	nm0001452		Sir Wilfrid Robarts
-30	1957	Acting	ACTOR	ACTOR	an0053518	Wild Is the Wind	tt0051193	Anthony Quinn	Anthony Quinn	nm0000063		Gino
+30	1957	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053515	Sayonara	tt0050933	Marlon Brando	Marlon Brando	nm0000008		Major Lloyd Gruver
+30	1957	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053516	A Hatful of Rain	tt0050487	Anthony Franciosa	Anthony Franciosa	nm0290047		Polo
+30	1957	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053514	The Bridge on the River Kwai	tt0050212	Alec Guinness	Alec Guinness	nm0000027	True	Colonel Nicholson
+30	1957	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053517	Witness for the Prosecution	tt0051201	Charles Laughton	Charles Laughton	nm0001452		Sir Wilfrid Robarts
+30	1957	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053518	Wild Is the Wind	tt0051193	Anthony Quinn	Anthony Quinn	nm0000063		Gino
 30	1957	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053524	Sayonara	tt0050933	Red Buttons	Red Buttons	nm0000999	True	Joe Kelly
 30	1957	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053525	A Farewell to Arms	tt0050379	Vittorio De Sica	Vittorio De Sica	nm0001120		Major Alessandro Rinaldi
 30	1957	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053526	The Bridge on the River Kwai	tt0050212	Sessue Hayakawa	Sessue Hayakawa	nm0370564		Saito
 30	1957	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053527	Peyton Place	tt0050839	Arthur Kennedy	Arthur Kennedy	nm0447913		Lucas Cross
 30	1957	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053528	Peyton Place	tt0050839	Russ Tamblyn	Russ Tamblyn	nm0848560		Norman Page
-30	1957	Acting	ACTRESS	ACTRESS	an0053520	Heaven Knows, Mr. Allison	tt0050490	Deborah Kerr	Deborah Kerr	nm0000039		Sister Angela
-30	1957	Acting	ACTRESS	ACTRESS	an0053521	Wild Is the Wind	tt0051193	Anna Magnani	Anna Magnani	nm0536167		Gioia
-30	1957	Acting	ACTRESS	ACTRESS	an0053522	Raintree County	tt0050882	Elizabeth Taylor	Elizabeth Taylor	nm0000072		Susanna Drake
-30	1957	Acting	ACTRESS	ACTRESS	an0053523	Peyton Place	tt0050839	Lana Turner	Lana Turner	nm0001805		Constance MacKenzie
-30	1957	Acting	ACTRESS	ACTRESS	an0053519	The Three Faces of Eve	tt0051077	Joanne Woodward	Joanne Woodward	nm0940946	True	Eve White/Eve Black/Jane
+30	1957	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053520	Heaven Knows, Mr. Allison	tt0050490	Deborah Kerr	Deborah Kerr	nm0000039		Sister Angela
+30	1957	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053521	Wild Is the Wind	tt0051193	Anna Magnani	Anna Magnani	nm0536167		Gioia
+30	1957	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053522	Raintree County	tt0050882	Elizabeth Taylor	Elizabeth Taylor	nm0000072		Susanna Drake
+30	1957	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053523	Peyton Place	tt0050839	Lana Turner	Lana Turner	nm0001805		Constance MacKenzie
+30	1957	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053519	The Three Faces of Eve	tt0051077	Joanne Woodward	Joanne Woodward	nm0940946	True	Eve White/Eve Black/Jane
 30	1957	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053530	The Bachelor Party	tt0050156	Carolyn Jones	Carolyn Jones	nm0427700		The Existentialist
 30	1957	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053531	Witness for the Prosecution	tt0051201	Elsa Lanchester	Elsa Lanchester	nm0006471		Miss Plimsoll
 30	1957	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053532	Peyton Place	tt0050839	Hope Lange	Hope Lange	nm0486136		Selena Cross
@@ -3494,11 +3494,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 30	1957	Title	INTERNATIONAL FEATURE FILM	FOREIGN LANGUAGE FILM	an0053602	Mother India	tt0050188	India
 30	1957	Title	INTERNATIONAL FEATURE FILM	FOREIGN LANGUAGE FILM	an0053599	The Nights of Cabiria	tt0050783	Italy			True
 30	1957	Title	INTERNATIONAL FEATURE FILM	FOREIGN LANGUAGE FILM	an0053603	Nine Lives	tt0050762	Norway
-30	1957	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053582	An Affair to Remember	tt0050105	Hugo Friedhofer	Hugo Friedhofer	nm0006087
-30	1957	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053583	Boy on a Dolphin	tt0050208	Hugo Friedhofer	Hugo Friedhofer	nm0006087
-30	1957	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053581	The Bridge on the River Kwai	tt0050212	Malcolm Arnold	Malcolm Arnold	nm0002185	True
-30	1957	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053584	Perri	tt0050837	Paul Smith	Paul Smith	nm1345229
-30	1957	Music	MUSIC (Scoring)	MUSIC (Scoring)	an0053585	Raintree County	tt0050882	Johnny Green	Johnny Green	nm0338004
+30	1957	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053582	An Affair to Remember	tt0050105	Hugo Friedhofer	Hugo Friedhofer	nm0006087
+30	1957	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053583	Boy on a Dolphin	tt0050208	Hugo Friedhofer	Hugo Friedhofer	nm0006087
+30	1957	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053581	The Bridge on the River Kwai	tt0050212	Malcolm Arnold	Malcolm Arnold	nm0002185	True
+30	1957	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053584	Perri	tt0050837	Paul Smith	Paul Smith	nm1345229
+30	1957	Music	MUSIC (Original Song Score or Adaptation Score)	MUSIC (Scoring)	an0053585	Raintree County	tt0050882	Johnny Green	Johnny Green	nm0338004
 30	1957	Music	MUSIC (Original Song)	MUSIC (Song)	an0053577	An Affair to Remember	tt0050105	Music by Harry Warren; Lyrics by Harold Adamson and Leo McCarey	Harry Warren, Harold Adamson, Leo McCarey	nm0912851,nm0011488,nm0564970		An Affair To Remember
 30	1957	Music	MUSIC (Original Song)	MUSIC (Song)	an0053576	The Joker Is Wild	tt0050569	Music by James Van Heusen; Lyrics by Sammy Cahn	James Van Heusen, Sammy Cahn	nm0006329,nm0005991	True	All The Way
 30	1957	Music	MUSIC (Original Song)	MUSIC (Song)	an0053578	April Love	tt0050135	Music by Sammy Fain; Lyrics by Paul Francis Webster	Sammy Fain, Paul Francis Webster	nm0006066,nm0916990		April Love
@@ -3546,21 +3546,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 30	1957	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					SOCIÉTÉ D'OPTIQUE ET DE MECANIQUE DE HAUTE PRECISION		True	Lenses and Filters		To the SOCIÉTÉ D'OPTIQUE ET DE MECANIQUE DE HAUTE PRECISION for the development of a high speed vari-focal photographic lens.
 30	1957	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Harlan L. Baumbach, LORAND WARGO, HOWARD M. LITTLE, the UNICORN ENGINEERING CORP.		True	Laboratory		To HARLAN L. BAUMBACH, LORAND WARGO, HOWARD M. LITTLE and the UNICORN ENGINEERING CORP. for the development of an Automatic Printer Light Selector.
 30	1957	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Charles E. Sutter, WILLIAM B. SMITH, PARAMOUNT PICTURES CORP., GENERAL CABLE CORP.		True	Stage Operations		To CHARLES E. SUTTER, WILLIAM B. SMITH, PARAMOUNT PICTURES CORP. and GENERAL CABLE CORP. for the engineering and application to studio use of aluminum lightweight electrical cable and connectors.
-31	1958	Acting	ACTOR	ACTOR	an0055492	The Defiant Ones	tt0051525	Tony Curtis	Tony Curtis	nm0000348		John 'Joker' Jackson
-31	1958	Acting	ACTOR	ACTOR	an0055493	Cat on a Hot Tin Roof	tt0051459	Paul Newman	Paul Newman	nm0000056		Brick Pollitt
-31	1958	Acting	ACTOR	ACTOR	an0055491	Separate Tables	tt0052182	David Niven	David Niven	nm0000057	True	Major Pollock
-31	1958	Acting	ACTOR	ACTOR	an0055494	The Defiant Ones	tt0051525	Sidney Poitier	Sidney Poitier	nm0001627		Noah Cullen
-31	1958	Acting	ACTOR	ACTOR	an0055495	The Old Man and the Sea	tt0052027	Spencer Tracy	Spencer Tracy	nm0000075		The Old Man
+31	1958	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055492	The Defiant Ones	tt0051525	Tony Curtis	Tony Curtis	nm0000348		John 'Joker' Jackson
+31	1958	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055493	Cat on a Hot Tin Roof	tt0051459	Paul Newman	Paul Newman	nm0000056		Brick Pollitt
+31	1958	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055491	Separate Tables	tt0052182	David Niven	David Niven	nm0000057	True	Major Pollock
+31	1958	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055494	The Defiant Ones	tt0051525	Sidney Poitier	Sidney Poitier	nm0001627		Noah Cullen
+31	1958	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055495	The Old Man and the Sea	tt0052027	Spencer Tracy	Spencer Tracy	nm0000075		The Old Man
 31	1958	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055502	The Defiant Ones	tt0051525	Theodore Bikel	Theodore Bikel	nm0000942		Sheriff Max Muller
 31	1958	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055503	The Brothers Karamazov	tt0051435	Lee J. Cobb	Lee J. Cobb	nm0002011		Fyodor Karamazov
 31	1958	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055501	The Big Country	tt0051411	Burl Ives	Burl Ives	nm0412322	True	Rufus Hannassey
 31	1958	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055504	Some Came Running	tt0052218	Arthur Kennedy	Arthur Kennedy	nm0447913		Frank Hirsh
 31	1958	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055505	Teacher's Pet	tt0052278	Gig Young	Gig Young	nm0949574		Dr. Hugo Pine
-31	1958	Acting	ACTRESS	ACTRESS	an0055496	I Want to Live!	tt0051758	Susan Hayward	Susan Hayward	nm0001333	True	Barbara Graham
-31	1958	Acting	ACTRESS	ACTRESS	an0055497	Separate Tables	tt0052182	Deborah Kerr	Deborah Kerr	nm0000039		Sibyl Railton-Bell
-31	1958	Acting	ACTRESS	ACTRESS	an0055498	Some Came Running	tt0052218	Shirley MacLaine	Shirley MacLaine	nm0000511		Ginny Moorhead
-31	1958	Acting	ACTRESS	ACTRESS	an0055499	Auntie Mame	tt0051383	Rosalind Russell	Rosalind Russell	nm0751426		Auntie Mame Dennis
-31	1958	Acting	ACTRESS	ACTRESS	an0055500	Cat on a Hot Tin Roof	tt0051459	Elizabeth Taylor	Elizabeth Taylor	nm0000072		Maggie Pollitt
+31	1958	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055496	I Want to Live!	tt0051758	Susan Hayward	Susan Hayward	nm0001333	True	Barbara Graham
+31	1958	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055497	Separate Tables	tt0052182	Deborah Kerr	Deborah Kerr	nm0000039		Sibyl Railton-Bell
+31	1958	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055498	Some Came Running	tt0052218	Shirley MacLaine	Shirley MacLaine	nm0000511		Ginny Moorhead
+31	1958	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055499	Auntie Mame	tt0051383	Rosalind Russell	Rosalind Russell	nm0751426		Auntie Mame Dennis
+31	1958	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055500	Cat on a Hot Tin Roof	tt0051459	Elizabeth Taylor	Elizabeth Taylor	nm0000072		Maggie Pollitt
 31	1958	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055507	Auntie Mame	tt0051383	Peggy Cass	Peggy Cass	nm0143918		Agnes Gooch
 31	1958	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055506	Separate Tables	tt0052182	Wendy Hiller	Wendy Hiller	nm0384908	True	Pat Cooper
 31	1958	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055508	Some Came Running	tt0052218	Martha Hyer	Martha Hyer	nm0405054		Gwen French
@@ -3638,11 +3638,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 31	1958	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055578	The Kiss	tt0051821	John Patrick Hayes, Producer	John Patrick Hayes	nm0371080
 31	1958	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055579	Snows of Aorangi	tt0052208	New Zealand Screen Board	New Zealand Screen Board	co0032927
 31	1958	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055580	T Is for Tumbleweed	tt0052267	James A. Lebenthal, Producer	James A. Lebenthal	nm0495604
-31	1958	Production	SOUND	SOUND	an0055547	I Want to Live!	tt0051758	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
-31	1958	Production	SOUND	SOUND	an0055546	South Pacific	tt0052225	Todd-AO Sound Department, Fred Hynes, Sound Director	Todd-AO, Fred Hynes	co0016792,nm0405261	True
-31	1958	Production	SOUND	SOUND	an0055548	A Time to Love and a Time to Die	tt0052296	Universal-International Studio Sound Department, Leslie I. Carey, Sound Director	Universal-International, Leslie I. Carey	co0005073,nm0136989
-31	1958	Production	SOUND	SOUND	an0055549	Vertigo	tt0052357	Paramount Studio Sound Department, George Dutton, Sound Director	Paramount, George Dutton	co0023400,nm0244931
-31	1958	Production	SOUND	SOUND	an0055550	The Young Lions	tt0052415	20th Century-Fox Studio Sound Department, Carl Faulkner, Sound Director	20th Century-Fox, Carl Faulkner	co0028775,nm0269055
+31	1958	Production	SOUND MIXING	SOUND	an0055547	I Want to Live!	tt0051758	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
+31	1958	Production	SOUND MIXING	SOUND	an0055546	South Pacific	tt0052225	Todd-AO Sound Department, Fred Hynes, Sound Director	Todd-AO, Fred Hynes	co0016792,nm0405261	True
+31	1958	Production	SOUND MIXING	SOUND	an0055548	A Time to Love and a Time to Die	tt0052296	Universal-International Studio Sound Department, Leslie I. Carey, Sound Director	Universal-International, Leslie I. Carey	co0005073,nm0136989
+31	1958	Production	SOUND MIXING	SOUND	an0055549	Vertigo	tt0052357	Paramount Studio Sound Department, George Dutton, Sound Director	Paramount, George Dutton	co0023400,nm0244931
+31	1958	Production	SOUND MIXING	SOUND	an0055550	The Young Lions	tt0052415	20th Century-Fox Studio Sound Department, Carl Faulkner, Sound Director	20th Century-Fox, Carl Faulkner	co0028775,nm0269055
 31	1958	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0055556	tom thumb	tt0052427	Visual Effects by Tom Howard	Tom Howard	nm0397644	True
 31	1958	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0055557	Torpedo Run	tt0052303	Visual Effects by A. Arnold Gillespie; Audible Effects by Harold Humbrock	A. Arnold Gillespie, Harold Humbrock	nm0318901,nm0401724
 31	1958	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0055517	Cat on a Hot Tin Roof	tt0051459	Richard Brooks, James Poe	Richard Brooks, James Poe	nm0112218,nm0688117
@@ -3661,21 +3661,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 31	1958	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Panavision INC.		True	Lenses and Filters		To PANAVISION, INC., for the design and development of the Auto Panatar anamorphic photographic lens for 35mm CinemaScope photography.
 31	1958	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					WILLY BORBERG		True	Projection		To WILLY BORBERG of the General Precision Laboratory, Inc., for the development of a high speed intermittent movement for 35mm motion picture theatre projection equipment.
 31	1958	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0049546				Fred Ponedel, GEORGE BROWN, CONRAD BOYE	?,nm0113618,?	True	Stage Operations		To FRED PONEDEL, GEORGE BROWN and CONRAD BOYE of the Warner Bros. Special Effects Department for the design and fabrication of a new rapid fire marble gun.
-32	1959	Acting	ACTOR	ACTOR	an0055731	Room at the Top	tt0053226	Laurence Harvey	Laurence Harvey	nm0002131		Joe Lampton
-32	1959	Acting	ACTOR	ACTOR	an0055730	Ben-Hur	tt0052618	Charlton Heston	Charlton Heston	nm0000032	True	Judah Ben-Hur
-32	1959	Acting	ACTOR	ACTOR	an0055732	Some Like It Hot	tt0053291	Jack Lemmon	Jack Lemmon	nm0000493		Jerry/Daphne
-32	1959	Acting	ACTOR	ACTOR	an0055733	The Last Angry Man	tt0052990	Paul Muni	Paul Muni	nm0612847		Dr. Sam Abelman
-32	1959	Acting	ACTOR	ACTOR	an0055734	Anatomy of a Murder	tt0052561	James Stewart	James Stewart	nm0000071		Paul Biegler
+32	1959	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055731	Room at the Top	tt0053226	Laurence Harvey	Laurence Harvey	nm0002131		Joe Lampton
+32	1959	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055730	Ben-Hur	tt0052618	Charlton Heston	Charlton Heston	nm0000032	True	Judah Ben-Hur
+32	1959	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055732	Some Like It Hot	tt0053291	Jack Lemmon	Jack Lemmon	nm0000493		Jerry/Daphne
+32	1959	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055733	The Last Angry Man	tt0052990	Paul Muni	Paul Muni	nm0612847		Dr. Sam Abelman
+32	1959	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055734	Anatomy of a Murder	tt0052561	James Stewart	James Stewart	nm0000071		Paul Biegler
 32	1959	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055740	Ben-Hur	tt0052618	Hugh Griffith	Hugh Griffith	nm0341518	True	Sheik Ilderim
 32	1959	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055741	Anatomy of a Murder	tt0052561	Arthur O'Connell	Arthur O'Connell	nm0640023		Parnell McCarthy
 32	1959	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055742	Anatomy of a Murder	tt0052561	George C. Scott	George C. Scott	nm0001715		Claude Dancer
 32	1959	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055743	The Young Philadelphians	tt0053462	Robert Vaughn	Robert Vaughn	nm0001816		Chester Gwynn
 32	1959	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055744	The Diary of Anne Frank	tt0052738	Ed Wynn	Ed Wynn	nm0943956		Mr. Dussell
-32	1959	Acting	ACTRESS	ACTRESS	an0055736	Pillow Talk	tt0053172	Doris Day	Doris Day	nm0000013		Jan Morrow
-32	1959	Acting	ACTRESS	ACTRESS	an0055737	The Nun's Story	tt0053131	Audrey Hepburn	Audrey Hepburn	nm0000030		Sister Luke
-32	1959	Acting	ACTRESS	ACTRESS	an0055738	Suddenly, Last Summer	tt0053318	Katharine Hepburn	Katharine Hepburn	nm0000031		Mrs. Venable
-32	1959	Acting	ACTRESS	ACTRESS	an0055735	Room at the Top	tt0053226	Simone Signoret	Simone Signoret	nm0797531	True	Alice Aisgill
-32	1959	Acting	ACTRESS	ACTRESS	an0055739	Suddenly, Last Summer	tt0053318	Elizabeth Taylor	Elizabeth Taylor	nm0000072		Catherine Holly
+32	1959	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055736	Pillow Talk	tt0053172	Doris Day	Doris Day	nm0000013		Jan Morrow
+32	1959	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055737	The Nun's Story	tt0053131	Audrey Hepburn	Audrey Hepburn	nm0000030		Sister Luke
+32	1959	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055738	Suddenly, Last Summer	tt0053318	Katharine Hepburn	Katharine Hepburn	nm0000031		Mrs. Venable
+32	1959	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055735	Room at the Top	tt0053226	Simone Signoret	Simone Signoret	nm0797531	True	Alice Aisgill
+32	1959	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055739	Suddenly, Last Summer	tt0053318	Elizabeth Taylor	Elizabeth Taylor	nm0000072		Catherine Holly
 32	1959	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055746	Room at the Top	tt0053226	Hermione Baddeley	Hermione Baddeley	nm0045968		Elspeth
 32	1959	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055747	Imitation of Life	tt0052918	Susan Kohner	Susan Kohner	nm0463435		Sarah Jane (age 18)
 32	1959	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055748	Imitation of Life	tt0052918	Juanita Moore	Juanita Moore	nm0601428		Annie Johnson
@@ -3760,11 +3760,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 32	1959	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055828	Mysteries of the Deep	tt0053090	Walt Disney, Producer	Walt Disney	nm0000370
 32	1959	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055829	The Running, Jumping and Standing-Still Film	tt0053231	Peter Sellers, Producer	Peter Sellers	nm0000634
 32	1959	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055830	Skyscraper	tt0053282	Shirley Clarke, Willard Van Dyke and Irving Jacoby, Producers	Shirley Clarke, Willard Van Dyke, Irving Jacoby	nm0164999,nm0886757,nm0414991
-32	1959	Production	SOUND	SOUND	an0055795	Ben-Hur	tt0052618	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665	True
-32	1959	Production	SOUND	SOUND	an0055796	Journey to the Center of the Earth	tt0052948	20th Century-Fox Studio Sound Department, Carl Faulkner, Sound Director	20th Century-Fox, Carl Faulkner	co0028775,nm0269055
-32	1959	Production	SOUND	SOUND	an0055797	Libel!	tt0053003	Metro-Goldwyn-Mayer London Studio Sound Department, A. W. Watkins, Sound Director	Metro-Goldwyn-Mayer London, A. W. Watkins	?,nm0914249
-32	1959	Production	SOUND	SOUND	an0055798	The Nun's Story	tt0053131	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
-32	1959	Production	SOUND	SOUND	an0055799	Porgy and Bess	tt0053182	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director; and Todd-AO Sound Department, Fred Hynes, Sound Director	Samuel Goldwyn, Gordon E. Sawyer, Todd-AO, Fred Hynes	co0058013,nm0768167,co0016792,nm0405261
+32	1959	Production	SOUND MIXING	SOUND	an0055795	Ben-Hur	tt0052618	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665	True
+32	1959	Production	SOUND MIXING	SOUND	an0055796	Journey to the Center of the Earth	tt0052948	20th Century-Fox Studio Sound Department, Carl Faulkner, Sound Director	20th Century-Fox, Carl Faulkner	co0028775,nm0269055
+32	1959	Production	SOUND MIXING	SOUND	an0055797	Libel!	tt0053003	Metro-Goldwyn-Mayer London Studio Sound Department, A. W. Watkins, Sound Director	Metro-Goldwyn-Mayer London, A. W. Watkins	?,nm0914249
+32	1959	Production	SOUND MIXING	SOUND	an0055798	The Nun's Story	tt0053131	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
+32	1959	Production	SOUND MIXING	SOUND	an0055799	Porgy and Bess	tt0053182	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director; and Todd-AO Sound Department, Fred Hynes, Sound Director	Samuel Goldwyn, Gordon E. Sawyer, Todd-AO, Fred Hynes	co0058013,nm0768167,co0016792,nm0405261
 32	1959	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0055805	Ben-Hur	tt0052618	Visual Effects by A. Arnold Gillespie, Robert MacDonald; Audible Effects by Milo Lory	A. Arnold Gillespie, Robert MacDonald, Milo Lory	nm0318901,nm0531881,nm0521215	True
 32	1959	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0055806	Journey to the Center of the Earth	tt0052948	Visual Effects by L. B. Abbott, James B. Gordon; Audible Effects by Carl Faulkner	L. B. Abbott, James B. Gordon, Carl Faulkner	nm0008004,nm0330286,nm0269055
 32	1959	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0055756	Anatomy of a Murder	tt0052561	Wendell Mayes	Wendell Mayes	nm0562606
@@ -3787,21 +3787,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 32	1959	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					ROBERT P. GUTTERMAN, LIPSNER-SMITH CORP.		True	Laboratory		To ROBERT P. GUTTERMAN of General Kinetics, Inc., and LIPSNER-SMITH CORP. for the design and development of the CF-2 Ultra-sonic Film Cleaner.
 32	1959	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0049971				UB IWERKS	nm0412650	True	Laboratory		To UB IWERKS of Walt Disney Prods. for the design of an improved optical printer for special effects and matte shots.
 32	1959	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0049972				E.L. Stones, GLEN ROBINSON, WINFIELD HUBBARD, LUTHER NEWMAN	?,nm0732656,nm1932076,nm1930051	True	Stage Operations		To E.L. STONES, GLEN ROBINSON, WINFIELD HUBBARD and LUTHER NEWMAN of the Metro-Goldwyn-Mayer Studio Construction Department for the design of a multiple cable remote controlled winch.
-33	1960	Acting	ACTOR	ACTOR	an0051847	Sons and Lovers	tt0054326	Trevor Howard	Trevor Howard	nm0002145		Morel
-33	1960	Acting	ACTOR	ACTOR	an0051846	Elmer Gantry	tt0053793	Burt Lancaster	Burt Lancaster	nm0000044	True	Elmer Gantry
-33	1960	Acting	ACTOR	ACTOR	an0051848	The Apartment	tt0053604	Jack Lemmon	Jack Lemmon	nm0000493		C.C. 'Bud' Baxter
-33	1960	Acting	ACTOR	ACTOR	an0051849	The Entertainer	tt0053796	Laurence Olivier	Laurence Olivier	nm0000059		Archie Rice
-33	1960	Acting	ACTOR	ACTOR	an0051850	Inherit the Wind	tt0053946	Spencer Tracy	Spencer Tracy	nm0000075		Henry Drummond
+33	1960	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051847	Sons and Lovers	tt0054326	Trevor Howard	Trevor Howard	nm0002145		Morel
+33	1960	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051846	Elmer Gantry	tt0053793	Burt Lancaster	Burt Lancaster	nm0000044	True	Elmer Gantry
+33	1960	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051848	The Apartment	tt0053604	Jack Lemmon	Jack Lemmon	nm0000493		C.C. 'Bud' Baxter
+33	1960	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051849	The Entertainer	tt0053796	Laurence Olivier	Laurence Olivier	nm0000059		Archie Rice
+33	1960	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051850	Inherit the Wind	tt0053946	Spencer Tracy	Spencer Tracy	nm0000075		Henry Drummond
 33	1960	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051857	Murder, Inc.	tt0054102	Peter Falk	Peter Falk	nm0000393		Abe Reles
 33	1960	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051858	The Apartment	tt0053604	Jack Kruschen	Jack Kruschen	nm0472816		Dr. Dreyfuss
 33	1960	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051859	Exodus	tt0053804	Sal Mineo	Sal Mineo	nm0000543		Dov Landau
 33	1960	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051856	Spartacus	tt0054331	Peter Ustinov	Peter Ustinov	nm0001811	True	Batiatus
 33	1960	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051860	The Alamo	tt0053580	Chill Wills	Chill Wills	nm0932629		Beekeeper
-33	1960	Acting	ACTRESS	ACTRESS	an0051852	Sunrise at Campobello	tt0054354	Greer Garson	Greer Garson	nm0002093		Eleanor Roosevelt
-33	1960	Acting	ACTRESS	ACTRESS	an0051853	The Sundowners	tt0054353	Deborah Kerr	Deborah Kerr	nm0000039		Ida Carmody
-33	1960	Acting	ACTRESS	ACTRESS	an0051854	The Apartment	tt0053604	Shirley MacLaine	Shirley MacLaine	nm0000511		Fran Kubelik
-33	1960	Acting	ACTRESS	ACTRESS	an0051855	Never on Sunday	tt0054198	Melina Mercouri	Melina Mercouri	nm0580479		Ilya
-33	1960	Acting	ACTRESS	ACTRESS	an0051851	Butterfield 8	tt0053622	Elizabeth Taylor	Elizabeth Taylor	nm0000072	True	Gloria Wandrous
+33	1960	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051852	Sunrise at Campobello	tt0054354	Greer Garson	Greer Garson	nm0002093		Eleanor Roosevelt
+33	1960	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051853	The Sundowners	tt0054353	Deborah Kerr	Deborah Kerr	nm0000039		Ida Carmody
+33	1960	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051854	The Apartment	tt0053604	Shirley MacLaine	Shirley MacLaine	nm0000511		Fran Kubelik
+33	1960	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051855	Never on Sunday	tt0054198	Melina Mercouri	Melina Mercouri	nm0580479		Ilya
+33	1960	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051851	Butterfield 8	tt0053622	Elizabeth Taylor	Elizabeth Taylor	nm0000072	True	Gloria Wandrous
 33	1960	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051862	The Sundowners	tt0054353	Glynis Johns	Glynis Johns	nm0424318		Mrs. Firth
 33	1960	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051861	Elmer Gantry	tt0053793	Shirley Jones	Shirley Jones	nm0429250	True	Lulu Bains
 33	1960	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051863	The Dark at the Top of the Stairs	tt0053750	Shirley Knight	Shirley Knight	nm0004309		Reenie
@@ -3888,11 +3888,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 33	1960	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0389429	Day of the Painter	tt0053753	Ezra R. Baker, Producer	Ezra R. Baker	nm0048441	True
 33	1960	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0051945	Islands of the Sea	tt0053956	Walt Disney, Producer	Walt Disney	nm0000370
 33	1960	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0051946	A Sport Is Born	tt0054335	Leslie Winik, Producer	Leslie Winik	nm0935119
-33	1960	Production	SOUND	SOUND	an0051911	The Alamo	tt0053580	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director; and Todd-AO Sound Department, Fred Hynes, Sound Director	Samuel Goldwyn, Gordon E. Sawyer, Todd-AO, Fred Hynes	co0058013,nm0768167,co0016792,nm0405261	True
-33	1960	Production	SOUND	SOUND	an0051912	The Apartment	tt0053604	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
-33	1960	Production	SOUND	SOUND	an0051913	Cimarron	tt0053715	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665
-33	1960	Production	SOUND	SOUND	an0765196	Pepe	tt0054172	Columbia Studio Sound Department, Charles Rice, Sound Director	Columbia, Charles Rice	co0050868,nm0723376
-33	1960	Production	SOUND	SOUND	an0051915	Sunrise at Campobello	tt0054354	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
+33	1960	Production	SOUND MIXING	SOUND	an0051911	The Alamo	tt0053580	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director; and Todd-AO Sound Department, Fred Hynes, Sound Director	Samuel Goldwyn, Gordon E. Sawyer, Todd-AO, Fred Hynes	co0058013,nm0768167,co0016792,nm0405261	True
+33	1960	Production	SOUND MIXING	SOUND	an0051912	The Apartment	tt0053604	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
+33	1960	Production	SOUND MIXING	SOUND	an0051913	Cimarron	tt0053715	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665
+33	1960	Production	SOUND MIXING	SOUND	an0765196	Pepe	tt0054172	Columbia Studio Sound Department, Charles Rice, Sound Director	Columbia, Charles Rice	co0050868,nm0723376
+33	1960	Production	SOUND MIXING	SOUND	an0051915	Sunrise at Campobello	tt0054354	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
 33	1960	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0051922	The Last Voyage	tt0054016	Visual Effects by A.J. Lohman	A.J. Lohman	nm0517846
 33	1960	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0051921	The Time Machine	tt0054387	Visual Effects by Gene Warren, Tim Baar	Gene Warren, Tim Baar	nm0912840,nm0056579	True
 33	1960	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0051871	Elmer Gantry	tt0053793	Richard Brooks	Richard Brooks	nm0112218	True
@@ -3913,21 +3913,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 33	1960	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0047699				Arthur Holcomb, Petro Vlahos, Columbia	?,nm1468620,co0050868	True	Photography		To ARTHUR HOLCOMB, PETRO VLAHOS and COLUMBIA STUDIO CAMERA DEPARTMENT for a camera flicker indicating device.
 33	1960	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Anthony Paglia, 20Th Century-Fox Studio		True	Stage Operations		To ANTHONY PAGLIA and the 20TH CENTURY-FOX STUDIO MECHANICAL EFFECTS DEPARTMENT for the design and construction of a miniature flak gun and ammunition.
 33	1960	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Carl Hauge, ROBERT GRUBEL, EDWARD REICHARD		True	Laboratory		To CARL HAUGE, ROBERT GRUBEL and EDWARD REICHARD of Consolidated Film Industries for the development of an automatic developer replenisher system.
-34	1961	Acting	ACTOR	ACTOR	an0048399	Fanny	tt0054866	Charles Boyer	Charles Boyer	nm0000964		César
-34	1961	Acting	ACTOR	ACTOR	an0048400	The Hustler	tt0054997	Paul Newman	Paul Newman	nm0000056		Eddie Felson
-34	1961	Acting	ACTOR	ACTOR	an0048398	Judgment at Nuremberg	tt0055031	Maximilian Schell	Maximilian Schell	nm0001703	True	Hans Rolfe
-34	1961	Acting	ACTOR	ACTOR	an0048401	Judgment at Nuremberg	tt0055031	Spencer Tracy	Spencer Tracy	nm0000075		Judge Dan Haywood
-34	1961	Acting	ACTOR	ACTOR	an0048402	The Mark	tt0055146	Stuart Whitman	Stuart Whitman	nm0926183		Jim Fuller
+34	1961	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048399	Fanny	tt0054866	Charles Boyer	Charles Boyer	nm0000964		César
+34	1961	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048400	The Hustler	tt0054997	Paul Newman	Paul Newman	nm0000056		Eddie Felson
+34	1961	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048398	Judgment at Nuremberg	tt0055031	Maximilian Schell	Maximilian Schell	nm0001703	True	Hans Rolfe
+34	1961	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048401	Judgment at Nuremberg	tt0055031	Spencer Tracy	Spencer Tracy	nm0000075		Judge Dan Haywood
+34	1961	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048402	The Mark	tt0055146	Stuart Whitman	Stuart Whitman	nm0926183		Jim Fuller
 34	1961	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048408	West Side Story	tt0055614	George Chakiris	George Chakiris	nm0001995	True	Bernardo
 34	1961	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048409	Judgment at Nuremberg	tt0055031	Montgomery Clift	Montgomery Clift	nm0001050		Rudolph Petersen
 34	1961	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048410	Pocketful of Miracles	tt0055312	Peter Falk	Peter Falk	nm0000393		Joy Boy
 34	1961	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048411	The Hustler	tt0054997	Jackie Gleason	Jackie Gleason	nm0001276		Minnesota Fats
 34	1961	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048412	The Hustler	tt0054997	George C. Scott	George C. Scott	nm0001715		Bert Gordon
-34	1961	Acting	ACTRESS	ACTRESS	an0048404	Breakfast at Tiffany's	tt0054698	Audrey Hepburn	Audrey Hepburn	nm0000030		Holly Golightly
-34	1961	Acting	ACTRESS	ACTRESS	an0048405	The Hustler	tt0054997	Piper Laurie	Piper Laurie	nm0001453		Sarah Packard
-34	1961	Acting	ACTRESS	ACTRESS	an0048403	Two Women	tt0054749	Sophia Loren	Sophia Loren	nm0000047	True	Cesira
-34	1961	Acting	ACTRESS	ACTRESS	an0048406	Summer and Smoke	tt0055489	Geraldine Page	Geraldine Page	nm0656183		Alma Winemiller
-34	1961	Acting	ACTRESS	ACTRESS	an0048407	Splendor in the Grass	tt0055471	Natalie Wood	Natalie Wood	nm0000081		Wilma Dean Loomis
+34	1961	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048404	Breakfast at Tiffany's	tt0054698	Audrey Hepburn	Audrey Hepburn	nm0000030		Holly Golightly
+34	1961	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048405	The Hustler	tt0054997	Piper Laurie	Piper Laurie	nm0001453		Sarah Packard
+34	1961	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048403	Two Women	tt0054749	Sophia Loren	Sophia Loren	nm0000047	True	Cesira
+34	1961	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048406	Summer and Smoke	tt0055489	Geraldine Page	Geraldine Page	nm0656183		Alma Winemiller
+34	1961	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048407	Splendor in the Grass	tt0055471	Natalie Wood	Natalie Wood	nm0000081		Wilma Dean Loomis
 34	1961	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048414	The Children's Hour	tt0054743	Fay Bainter	Fay Bainter	nm0047810		Mrs. Amelia Tilford
 34	1961	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048415	Judgment at Nuremberg	tt0055031	Judy Garland	Judy Garland	nm0000023		Irene Hoffman
 34	1961	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048416	The Roman Spring of Mrs. Stone	tt0055382	Lotte Lenya	Lotte Lenya	nm0502322		Countess Magda Terribili-Gonzales
@@ -4015,11 +4015,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 34	1961	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048498	Rooftops of New York	tt0055384	Robert Gaffney, Producer	Robert Gaffney	nm0300759
 34	1961	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048495	Seawards the Great Ships	tt0055420	Templar Film Studios	Templar Film Studios	co0127441	True
 34	1961	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048499	Very Nice, Very Nice	tt0055594	National Film Board of Canada	National Film Board of Canada	co0006414
-34	1961	Production	SOUND	SOUND	an0048464	The Children's Hour	tt0054743	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
-34	1961	Production	SOUND	SOUND	an0048465	Flower Drum Song	tt0054885	Revue Studio Sound Department, Waldon O. Watson, Sound Director	Revue, Waldon O. Watson	?,nm0910592
-34	1961	Production	SOUND	SOUND	an0048466	The Guns of Navarone	tt0054953	Shepperton Studio Sound Department, John Cox, Sound Director	Shepperton, John Cox	?,nm0185090
-34	1961	Production	SOUND	SOUND	an0048467	The Parent Trap	tt0055277	Walt Disney Studio Sound Department, Robert O. Cook, Sound Director	Walt Disney Studios, Robert O. Cook	co0008970,nm0177256
-34	1961	Production	SOUND	SOUND	an0048463	West Side Story	tt0055614	Todd-AO Sound Department, Fred Hynes, Sound Director; and Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Todd-AO, Fred Hynes, Samuel Goldwyn, Gordon E. Sawyer	co0016792,nm0405261,co0058013,nm0768167	True
+34	1961	Production	SOUND MIXING	SOUND	an0048464	The Children's Hour	tt0054743	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
+34	1961	Production	SOUND MIXING	SOUND	an0048465	Flower Drum Song	tt0054885	Revue Studio Sound Department, Waldon O. Watson, Sound Director	Revue, Waldon O. Watson	?,nm0910592
+34	1961	Production	SOUND MIXING	SOUND	an0048466	The Guns of Navarone	tt0054953	Shepperton Studio Sound Department, John Cox, Sound Director	Shepperton, John Cox	?,nm0185090
+34	1961	Production	SOUND MIXING	SOUND	an0048467	The Parent Trap	tt0055277	Walt Disney Studio Sound Department, Robert O. Cook, Sound Director	Walt Disney Studios, Robert O. Cook	co0008970,nm0177256
+34	1961	Production	SOUND MIXING	SOUND	an0048463	West Side Story	tt0055614	Todd-AO Sound Department, Fred Hynes, Sound Director; and Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Todd-AO, Fred Hynes, Samuel Goldwyn, Gordon E. Sawyer	co0016792,nm0405261,co0058013,nm0768167	True
 34	1961	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0048474	The Absent Minded Professor	tt0054594	Visual Effects by Robert A. Mattey, Eustace Lycett	Robert A. Mattey, Eustace Lycett	nm0559871,nm0527941
 34	1961	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0048473	The Guns of Navarone	tt0054953	Visual Effects by Bill Warrington; Audible Effects by Vivian C. Greenham	Bill Warrington, Vivian C. Greenham	nm0913113,nm0339051	True
 34	1961	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0048424	Breakfast at Tiffany's	tt0054698	George Axelrod	George Axelrod	nm0043480
@@ -4042,21 +4042,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 34	1961	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0056660				20Th Century-Fox, E.I. Sponable, Herbert E. Bragg, Deluxe Laboratories Inc., F.D. Leslie, R.D. Whitmore, A.A. Alden, Endel Pool, James B. Gordon	co0028775,?,?,?,?,?,?,?,nm0330286	True	Laboratory		To 20TH CENTURY-FOX RESEARCH DEPARTMENT, under the direction of E.I. SPONABLE and HERBERT E. BRAGG, and DELUXE LABORATORIES, INC., with the assistance of F.D. LESLIE, R.D. WHITMORE, A.A. ALDEN, ENDEL POOL and JAMES B. GORDON for a system of decompressing and recomposing CinemaScope pictures for conventional aspect ratios.
 34	1961	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Hurletron Inc.		True	Laboratory		To HURLETRON, INC., ELECTRIC EYE EQUIPMENT DIVISION, for an automatic light changing system for motion picture printers.
 34	1961	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					WADSWORTH E. POHL, TECHNICOLOR CORP.		True	Laboratory		To WADSWORTH E. POHL and TECHNICOLOR CORP. for an integrated sound and picture transfer process.
-35	1962	Acting	ACTOR	ACTOR	an0053644	Birdman of Alcatraz	tt0055798	Burt Lancaster	Burt Lancaster	nm0000044		Robert Stroud
-35	1962	Acting	ACTOR	ACTOR	an0053645	Days of Wine and Roses	tt0055895	Jack Lemmon	Jack Lemmon	nm0000493		Joe Clay
-35	1962	Acting	ACTOR	ACTOR	an0053646	Divorce--Italian Style	tt0055913	Marcello Mastroianni	Marcello Mastroianni	nm0000052		Ferdinando Cefalu
-35	1962	Acting	ACTOR	ACTOR	an0053647	Lawrence of Arabia	tt0056172	Peter O'Toole	Peter O'Toole	nm0000564		T.E. Lawrence
-35	1962	Acting	ACTOR	ACTOR	an0053643	To Kill a Mockingbird	tt0056592	Gregory Peck	Gregory Peck	nm0000060	True	Atticus Finch
+35	1962	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053644	Birdman of Alcatraz	tt0055798	Burt Lancaster	Burt Lancaster	nm0000044		Robert Stroud
+35	1962	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053645	Days of Wine and Roses	tt0055895	Jack Lemmon	Jack Lemmon	nm0000493		Joe Clay
+35	1962	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053646	Divorce--Italian Style	tt0055913	Marcello Mastroianni	Marcello Mastroianni	nm0000052		Ferdinando Cefalu
+35	1962	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053647	Lawrence of Arabia	tt0056172	Peter O'Toole	Peter O'Toole	nm0000564		T.E. Lawrence
+35	1962	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053643	To Kill a Mockingbird	tt0056592	Gregory Peck	Gregory Peck	nm0000060	True	Atticus Finch
 35	1962	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053653	Sweet Bird of Youth	tt0056541	Ed Begley	Ed Begley	nm0003225	True	Tom 'Boss' Finley
 35	1962	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053654	What Ever Happened to Baby Jane?	tt0056687	Victor Buono	Victor Buono	nm0120658		Edwin Flagg
 35	1962	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053655	Birdman of Alcatraz	tt0055798	Telly Savalas	Telly Savalas	nm0001699		Feto Gomez
 35	1962	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053656	Lawrence of Arabia	tt0056172	Omar Sharif	Omar Sharif	nm0001725		Sherif Ali ibn el Kharish
 35	1962	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053657	Billy Budd	tt0055796	Terence Stamp	Terence Stamp	nm0000654		Billy Budd
-35	1962	Acting	ACTRESS	ACTRESS	an0053648	The Miracle Worker	tt0056241	Anne Bancroft	Anne Bancroft	nm0000843	True	Annie Sullivan
-35	1962	Acting	ACTRESS	ACTRESS	an0053649	What Ever Happened to Baby Jane?	tt0056687	Bette Davis	Bette Davis	nm0000012		Jane Hudson
-35	1962	Acting	ACTRESS	ACTRESS	an0053650	Long Day's Journey into Night	tt0056196	Katharine Hepburn	Katharine Hepburn	nm0000031		Mary Tyrone
-35	1962	Acting	ACTRESS	ACTRESS	an0053651	Sweet Bird of Youth	tt0056541	Geraldine Page	Geraldine Page	nm0656183		Alexandra Del Lago
-35	1962	Acting	ACTRESS	ACTRESS	an0053652	Days of Wine and Roses	tt0055895	Lee Remick	Lee Remick	nm0001665		Kirsten Arnesen
+35	1962	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053648	The Miracle Worker	tt0056241	Anne Bancroft	Anne Bancroft	nm0000843	True	Annie Sullivan
+35	1962	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053649	What Ever Happened to Baby Jane?	tt0056687	Bette Davis	Bette Davis	nm0000012		Jane Hudson
+35	1962	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053650	Long Day's Journey into Night	tt0056196	Katharine Hepburn	Katharine Hepburn	nm0000031		Mary Tyrone
+35	1962	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053651	Sweet Bird of Youth	tt0056541	Geraldine Page	Geraldine Page	nm0656183		Alexandra Del Lago
+35	1962	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053652	Days of Wine and Roses	tt0055895	Lee Remick	Lee Remick	nm0001665		Kirsten Arnesen
 35	1962	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053659	To Kill a Mockingbird	tt0056592	Mary Badham	Mary Badham	nm0000825		Scout Finch
 35	1962	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053658	The Miracle Worker	tt0056241	Patty Duke	Patty Duke	nm0001157	True	Helen Keller
 35	1962	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053660	Sweet Bird of Youth	tt0056541	Shirley Knight	Shirley Knight	nm0004309		Heavenly Finley
@@ -4142,11 +4142,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 35	1962	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0053743	The Cliff Dwellers (formerly titled 'One Plus One')	tt0055853	Hayward Anderson, Producer	Hayward Anderson	nm0026794
 35	1962	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0053740	Heureux Anniversaire (Happy Anniversary)	tt0056066	Pierre Etaix and J.C. Carrière, Producers	Pierre Etaix, J.C. Carrière	nm0959916,nm0140643	True
 35	1962	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0053744	Pan	tt1534484	Herman van der Horst, Producer	Herman van der Horst	nm0395474
-35	1962	Production	SOUND	SOUND	an0053709	Bon Voyage!	tt0055807	Walt Disney Studio Sound Department, Robert O. Cook, Sound Director	Walt Disney Studios, Robert O. Cook	co0008970,nm0177256
-35	1962	Production	SOUND	SOUND	an0053708	Lawrence of Arabia	tt0056172	Shepperton Studio Sound Department, John Cox, Sound Director	Shepperton, John Cox	?,nm0185090	True
-35	1962	Production	SOUND	SOUND	an0053710	Meredith Willson's The Music Man	tt0056262	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
-35	1962	Production	SOUND	SOUND	an0053711	That Touch of Mink	tt0056575	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
-35	1962	Production	SOUND	SOUND	an0053712	What Ever Happened to Baby Jane?	tt0056687	Glen Glenn Sound Department, Joseph Kelly, Sound Director	Glen Glenn, Joseph Kelly	co0000175,nm1369113
+35	1962	Production	SOUND MIXING	SOUND	an0053709	Bon Voyage!	tt0055807	Walt Disney Studio Sound Department, Robert O. Cook, Sound Director	Walt Disney Studios, Robert O. Cook	co0008970,nm0177256
+35	1962	Production	SOUND MIXING	SOUND	an0053708	Lawrence of Arabia	tt0056172	Shepperton Studio Sound Department, John Cox, Sound Director	Shepperton, John Cox	?,nm0185090	True
+35	1962	Production	SOUND MIXING	SOUND	an0053710	Meredith Willson's The Music Man	tt0056262	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
+35	1962	Production	SOUND MIXING	SOUND	an0053711	That Touch of Mink	tt0056575	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
+35	1962	Production	SOUND MIXING	SOUND	an0053712	What Ever Happened to Baby Jane?	tt0056687	Glen Glenn Sound Department, Joseph Kelly, Sound Director	Glen Glenn, Joseph Kelly	co0000175,nm1369113
 35	1962	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0053718	The Longest Day	tt0056197	Visual Effects by Robert MacDonald; Audible Effects by Jacques Maumont	Robert MacDonald, Jacques Maumont	nm0531881,nm0560918	True
 35	1962	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0053719	Mutiny on the Bounty	tt0056264	Visual Effects by A. Arnold Gillespie; Audible Effects by Milo Lory	A. Arnold Gillespie, Milo Lory	nm0318901,nm0521215
 35	1962	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0053669	David and Lisa	tt0055892	Eleanor Perry	Eleanor Perry	nm0675052
@@ -4166,21 +4166,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 35	1962	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Charles E. Sutter, WILLIAM BRYSON SMITH, LOUIS C. KENNELL		True	Lighting		To CHARLES E. SUTTER, WILLIAM BRYSON SMITH and LOUIS C. KENNELL of Paramount Pictures Corp. for the engineering and application to motion picture production of a new system of electric power distribution.
 35	1962	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Electro-Voice Inc.,		True	Sound		To ELECTRO-VOICE, INC., for a highly directional dynamic line microphone.
 35	1962	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					LOUIS G. MacKENZIE		True	Sound		To LOUIS G. MacKENZIE for a selective sound effects repeater.
-36	1963	Acting	ACTOR	ACTOR	an0048127	Tom Jones	tt0057590	Albert Finney	Albert Finney	nm0001215		Tom Jones
-36	1963	Acting	ACTOR	ACTOR	an0048128	This Sporting Life	tt0057578	Richard Harris	Richard Harris	nm0001321		Frank Machin
-36	1963	Acting	ACTOR	ACTOR	an0048129	Cleopatra	tt0056937	Rex Harrison	Rex Harrison	nm0001322		Julius Caesar
-36	1963	Acting	ACTOR	ACTOR	an0048130	Hud	tt0057163	Paul Newman	Paul Newman	nm0000056		Hud Bannon
-36	1963	Acting	ACTOR	ACTOR	an0048126	Lilies of the Field	tt0057251	Sidney Poitier	Sidney Poitier	nm0001627	True	Homer Smith
+36	1963	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048127	Tom Jones	tt0057590	Albert Finney	Albert Finney	nm0001215		Tom Jones
+36	1963	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048128	This Sporting Life	tt0057578	Richard Harris	Richard Harris	nm0001321		Frank Machin
+36	1963	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048129	Cleopatra	tt0056937	Rex Harrison	Rex Harrison	nm0001322		Julius Caesar
+36	1963	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048130	Hud	tt0057163	Paul Newman	Paul Newman	nm0000056		Hud Bannon
+36	1963	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048126	Lilies of the Field	tt0057251	Sidney Poitier	Sidney Poitier	nm0001627	True	Homer Smith
 36	1963	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048137	Twilight of Honor	tt0057609	Nick Adams	Nick Adams	nm0011244		Ben Brown
 36	1963	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048138	Captain Newman, M.D.	tt0056903	Bobby Darin	Bobby Darin	nm0201239		Corp. Jim Tompkins
 36	1963	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048136	Hud	tt0057163	Melvyn Douglas	Melvyn Douglas	nm0002048	True	Homer Bannon
 36	1963	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048139	Tom Jones	tt0057590	Hugh Griffith	Hugh Griffith	nm0341518		Squire Western
 36	1963	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048140	The Cardinal	tt0056907	John Huston	John Huston	nm0001379		Cardinal Glennon
-36	1963	Acting	ACTRESS	ACTRESS	an0048132	The L-Shaped Room	tt0057239	Leslie Caron	Leslie Caron	nm0001989		Jane
-36	1963	Acting	ACTRESS	ACTRESS	an0048133	Irma La Douce	tt0057187	Shirley MacLaine	Shirley MacLaine	nm0000511		Irma La Douce
-36	1963	Acting	ACTRESS	ACTRESS	an0048131	Hud	tt0057163	Patricia Neal	Patricia Neal	nm0623658	True	Alma
-36	1963	Acting	ACTRESS	ACTRESS	an0048134	This Sporting Life	tt0057578	Rachel Roberts	Rachel Roberts	nm0731499		Mrs. Hammond
-36	1963	Acting	ACTRESS	ACTRESS	an0048135	Love with the Proper Stranger	tt0057263	Natalie Wood	Natalie Wood	nm0000081		Angie
+36	1963	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048132	The L-Shaped Room	tt0057239	Leslie Caron	Leslie Caron	nm0001989		Jane
+36	1963	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048133	Irma La Douce	tt0057187	Shirley MacLaine	Shirley MacLaine	nm0000511		Irma La Douce
+36	1963	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048131	Hud	tt0057163	Patricia Neal	Patricia Neal	nm0623658	True	Alma
+36	1963	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048134	This Sporting Life	tt0057578	Rachel Roberts	Rachel Roberts	nm0731499		Mrs. Hammond
+36	1963	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048135	Love with the Proper Stranger	tt0057263	Natalie Wood	Natalie Wood	nm0000081		Angie
 36	1963	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048142	Tom Jones	tt0057590	Diane Cilento	Diane Cilento	nm0162283		Molly
 36	1963	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048143	Tom Jones	tt0057590	Dame Edith Evans	Dame Edith Evans	nm0262725		Miss Western
 36	1963	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048144	Tom Jones	tt0057590	Joyce Redman	Joyce Redman	nm0715010		Mrs. Waters
@@ -4270,11 +4270,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 36	1963	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048225	An Occurrence at Owl Creek Bridge	tt0056300	Paul de Roubaix and Marcel Ichac, Producers	Paul de Roubaix, Marcel Ichac	nm0745515,nm0406685	True
 36	1963	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048228	Six-Sided Triangle	tt0057506	Christopher Miles, Producer	Christopher Miles	nm0587085
 36	1963	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048229	That's Me	tt0057575	Walker Stuart, Producer	Walker Stuart	nm0835872
-36	1963	Production	SOUND	SOUND	an0769038	Bye Bye Birdie	tt0056891	Columbia Studio Sound Department, Charles Rice, Sound Director	Columbia, Charles Rice	co0050868,nm0723376
-36	1963	Production	SOUND	SOUND	an0048193	Captain Newman, M.D.	tt0056903	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
-36	1963	Production	SOUND	SOUND	an0048194	Cleopatra	tt0056937	20th Century-Fox Studio Sound Department, James P. Corcoran, Sound Director; and Todd-AO Sound Department, Fred Hynes, Sound Director	20th Century-Fox, James P. Corcoran, Todd-AO, Fred Hynes	co0028775,nm0179331,co0016792,nm0405261
-36	1963	Production	SOUND	SOUND	an0048191	How the West Was Won	tt0056085	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665	True
-36	1963	Production	SOUND	SOUND	an0048195	It's a Mad, Mad, Mad, Mad World	tt0057193	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
+36	1963	Production	SOUND MIXING	SOUND	an0769038	Bye Bye Birdie	tt0056891	Columbia Studio Sound Department, Charles Rice, Sound Director	Columbia, Charles Rice	co0050868,nm0723376
+36	1963	Production	SOUND MIXING	SOUND	an0048193	Captain Newman, M.D.	tt0056903	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
+36	1963	Production	SOUND MIXING	SOUND	an0048194	Cleopatra	tt0056937	20th Century-Fox Studio Sound Department, James P. Corcoran, Sound Director; and Todd-AO Sound Department, Fred Hynes, Sound Director	20th Century-Fox, James P. Corcoran, Todd-AO, Fred Hynes	co0028775,nm0179331,co0016792,nm0405261
+36	1963	Production	SOUND MIXING	SOUND	an0048191	How the West Was Won	tt0056085	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665	True
+36	1963	Production	SOUND MIXING	SOUND	an0048195	It's a Mad, Mad, Mad, Mad World	tt0057193	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
 36	1963	Production	SOUND EDITING	SOUND EFFECTS	an0048204	A Gathering of Eagles	tt0057090	Robert L. Bratton	Robert L. Bratton	nm0105600
 36	1963	Production	SOUND EDITING	SOUND EFFECTS	an0048203	It's a Mad, Mad, Mad, Mad World	tt0057193	Walter G. Elliott	Walter G. Elliott	nm0254666	True
 36	1963	Production	VISUAL EFFECTS	SPECIAL EFFECTS	an0048202	The Birds	tt0056869	Ub Iwerks	Ub Iwerks	nm0412650
@@ -4291,21 +4291,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 36	1963	Writing	WRITING (Original Screenplay)	WRITING (Story and Screenplay--written directly for the screen)	an0048160	Love with the Proper Stranger	tt0057263	Arnold Schulman	Arnold Schulman	nm0776068
 36	1963	Special	IRVING G. THALBERG MEMORIAL AWARD	IRVING G. THALBERG MEMORIAL AWARD	an0054649			Sam Spiegel	Sam Spiegel	nm0818545	True
 36	1963	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0054652				DOUGLAS G. SHEARER, A. ARNOLD GILLESPIE	nm0790428,nm0318901	True	Special Photographic		To DOUGLAS G. SHEARER and A. ARNOLD GILLESPIE of Metro-Goldwyn-Mayer Studios for the engineering of an improved Background Process Projection System.
-37	1964	Acting	ACTOR	ACTOR	an0052426	Becket	tt0057877	Richard Burton	Richard Burton	nm0000009		Thomas Becket
-37	1964	Acting	ACTOR	ACTOR	an0052425	My Fair Lady	tt0058385	Rex Harrison	Rex Harrison	nm0001322	True	Professor Henry Higgins
-37	1964	Acting	ACTOR	ACTOR	an0052427	Becket	tt0057877	Peter O'Toole	Peter O'Toole	nm0000564		King Henry II
-37	1964	Acting	ACTOR	ACTOR	an0052428	Zorba the Greek	tt0057831	Anthony Quinn	Anthony Quinn	nm0000063		Alexis Zorba
-37	1964	Acting	ACTOR	ACTOR	an0052429	Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb	tt0057012	Peter Sellers	Peter Sellers	nm0000634		Group Captain Lionel Mandrake/President Muffley/Dr. Strangelove
+37	1964	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052426	Becket	tt0057877	Richard Burton	Richard Burton	nm0000009		Thomas Becket
+37	1964	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052425	My Fair Lady	tt0058385	Rex Harrison	Rex Harrison	nm0001322	True	Professor Henry Higgins
+37	1964	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052427	Becket	tt0057877	Peter O'Toole	Peter O'Toole	nm0000564		King Henry II
+37	1964	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052428	Zorba the Greek	tt0057831	Anthony Quinn	Anthony Quinn	nm0000063		Alexis Zorba
+37	1964	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0052429	Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb	tt0057012	Peter Sellers	Peter Sellers	nm0000634		Group Captain Lionel Mandrake/President Muffley/Dr. Strangelove
 37	1964	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052436	Becket	tt0057877	John Gielgud	John Gielgud	nm0000024		King Louis VII of France
 37	1964	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052437	My Fair Lady	tt0058385	Stanley Holloway	Stanley Holloway	nm0391361		Alfred P. Doolittle
 37	1964	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052438	Seven Days in May	tt0058576	Edmond O'Brien	Edmond O'Brien	nm0639529		Senator Raymond Clark
 37	1964	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052439	The Best Man	tt0057883	Lee Tracy	Lee Tracy	nm0870543		Art Hockstader
 37	1964	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0052435	Topkapi	tt0058672	Peter Ustinov	Peter Ustinov	nm0001811	True	Arthur Simpson
-37	1964	Acting	ACTRESS	ACTRESS	an0052430	Mary Poppins	tt0058331	Julie Andrews	Julie Andrews	nm0000267	True	Mary Poppins
-37	1964	Acting	ACTRESS	ACTRESS	an0052431	The Pumpkin Eater	tt0058500	Anne Bancroft	Anne Bancroft	nm0000843		Jo Armitage
-37	1964	Acting	ACTRESS	ACTRESS	an0052432	Marriage Italian Style	tt0058335	Sophia Loren	Sophia Loren	nm0000047		Filomena Marturano
-37	1964	Acting	ACTRESS	ACTRESS	an0052433	The Unsinkable Molly Brown	tt0058708	Debbie Reynolds	Debbie Reynolds	nm0001666		Molly Brown
-37	1964	Acting	ACTRESS	ACTRESS	an0052434	Seance on a Wet Afternoon	tt0058557	Kim Stanley	Kim Stanley	nm0822535		Myra Savage
+37	1964	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052430	Mary Poppins	tt0058331	Julie Andrews	Julie Andrews	nm0000267	True	Mary Poppins
+37	1964	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052431	The Pumpkin Eater	tt0058500	Anne Bancroft	Anne Bancroft	nm0000843		Jo Armitage
+37	1964	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052432	Marriage Italian Style	tt0058335	Sophia Loren	Sophia Loren	nm0000047		Filomena Marturano
+37	1964	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052433	The Unsinkable Molly Brown	tt0058708	Debbie Reynolds	Debbie Reynolds	nm0001666		Molly Brown
+37	1964	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0052434	Seance on a Wet Afternoon	tt0058557	Kim Stanley	Kim Stanley	nm0822535		Myra Savage
 37	1964	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052441	My Fair Lady	tt0058385	Gladys Cooper	Gladys Cooper	nm0178066		Mrs. Higgins
 37	1964	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052442	The Chalk Garden	tt0057933	Dame Edith Evans	Dame Edith Evans	nm0262725		Mrs. St. Maugham
 37	1964	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0052443	The Night of the Iguana	tt0058404	Grayson Hall	Grayson Hall	nm0355621		Judith Fellowes
@@ -4393,11 +4393,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 37	1964	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0052523	Casals Conducts: 1964	tt0057922	Edward Schreiber, Producer	Edward Schreiber	nm0775233	True
 37	1964	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0052524	Help! My Snowman's Burning Down	tt0058189	Carson Davidson, Producer	Carson Davidson	nm0203262
 37	1964	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0052525	The Legend of Jimmy Blue Eyes	tt0058288	Robert Clouse, Producer	Robert Clouse	nm0167195
-37	1964	Production	SOUND	SOUND	an0052491	Becket	tt0057877	Shepperton Studio Sound Department, John Cox, Sound Director	Shepperton, John Cox	?,nm0185090
-37	1964	Production	SOUND	SOUND	an0052492	Father Goose	tt0058092	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
-37	1964	Production	SOUND	SOUND	an0052493	Mary Poppins	tt0058331	Walt Disney Studio Sound Department, Robert O. Cook, Sound Director	Walt Disney Studios, Robert O. Cook	co0008970,nm0177256
-37	1964	Production	SOUND	SOUND	an0052490	My Fair Lady	tt0058385	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060	True
-37	1964	Production	SOUND	SOUND	an0052494	The Unsinkable Molly Brown	tt0058708	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665
+37	1964	Production	SOUND MIXING	SOUND	an0052491	Becket	tt0057877	Shepperton Studio Sound Department, John Cox, Sound Director	Shepperton, John Cox	?,nm0185090
+37	1964	Production	SOUND MIXING	SOUND	an0052492	Father Goose	tt0058092	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
+37	1964	Production	SOUND MIXING	SOUND	an0052493	Mary Poppins	tt0058331	Walt Disney Studio Sound Department, Robert O. Cook, Sound Director	Walt Disney Studios, Robert O. Cook	co0008970,nm0177256
+37	1964	Production	SOUND MIXING	SOUND	an0052490	My Fair Lady	tt0058385	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060	True
+37	1964	Production	SOUND MIXING	SOUND	an0052494	The Unsinkable Molly Brown	tt0058708	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665
 37	1964	Production	SOUND EDITING	SOUND EFFECTS	an0052502	Goldfinger	tt0058150	Norman Wanstall	Norman Wanstall	nm0911232	True
 37	1964	Production	SOUND EDITING	SOUND EFFECTS	an0052503	The Lively Set	tt0058296	Robert L. Bratton	Robert L. Bratton	nm0105600
 37	1964	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0052500	Mary Poppins	tt0058331	Peter Ellenshaw, Eustace Lycett, Hamilton Luske	Peter Ellenshaw, Eustace Lycett, Hamilton Luske	nm0254002,nm0527941,nm0527217	True
@@ -4422,21 +4422,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 37	1964	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					EDWARD H. REICHARD, CARL W. HAUGE		True	Laboratory		To EDWARD H. REICHARD and CARL W. HAUGE of Consolidated Film Industries for the design of a Proximity Cue Detector and its application to motion picture printers.
 37	1964	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Edward H. Reichard, LEONARD L. SOKOLOW, CARL W. HAUGE		True	Laboratory		To EDWARD H. REICHARD, LEONARD L. SOKOLOW and CARL W. HAUGE of Consolidated Film Industries for the design and application to motion picture laboratory practice of a Stroboscopic Scene Tester for color and black-and-white film.
 37	1964	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0053764				Nelson Tyler	nm0878874	True	Photography		To NELSON TYLER for the design and construction of an improved Helicopter Camera System.
-38	1965	Acting	ACTOR	ACTOR	an0054040	The Spy Who Came In from the Cold	tt0059749	Richard Burton	Richard Burton	nm0000009		Alec Leamas
-38	1965	Acting	ACTOR	ACTOR	an0054039	Cat Ballou	tt0059017	Lee Marvin	Lee Marvin	nm0001511	True	Kid Shelleen/Tim Strawn
-38	1965	Acting	ACTOR	ACTOR	an0054041	Othello	tt0059555	Laurence Olivier	Laurence Olivier	nm0000059		Othello
-38	1965	Acting	ACTOR	ACTOR	an0054042	The Pawnbroker	tt0059575	Rod Steiger	Rod Steiger	nm0001768		Sol Nazerman
-38	1965	Acting	ACTOR	ACTOR	an0054043	Ship of Fools	tt0059712	Oskar Werner	Oskar Werner	nm0921459		Dr. Schumann
+38	1965	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054040	The Spy Who Came In from the Cold	tt0059749	Richard Burton	Richard Burton	nm0000009		Alec Leamas
+38	1965	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054039	Cat Ballou	tt0059017	Lee Marvin	Lee Marvin	nm0001511	True	Kid Shelleen/Tim Strawn
+38	1965	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054041	Othello	tt0059555	Laurence Olivier	Laurence Olivier	nm0000059		Othello
+38	1965	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054042	The Pawnbroker	tt0059575	Rod Steiger	Rod Steiger	nm0001768		Sol Nazerman
+38	1965	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054043	Ship of Fools	tt0059712	Oskar Werner	Oskar Werner	nm0921459		Dr. Schumann
 38	1965	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054049	A Thousand Clowns	tt0059798	Martin Balsam	Martin Balsam	nm0000842	True	Arnold Burns
 38	1965	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054050	The Flight of the Phoenix	tt0059183	Ian Bannen	Ian Bannen	nm0000846		Crow
 38	1965	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054051	Doctor Zhivago	tt0059113	Tom Courtenay	Tom Courtenay	nm0183822		Pasha Antipov/Strelnikoff
 38	1965	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054052	Ship of Fools	tt0059712	Michael Dunn	Michael Dunn	nm0242692		Glocken
 38	1965	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054053	Othello	tt0059555	Frank Finlay	Frank Finlay	nm0277975		Iago
-38	1965	Acting	ACTRESS	ACTRESS	an0054045	The Sound of Music	tt0059742	Julie Andrews	Julie Andrews	nm0000267		Maria
-38	1965	Acting	ACTRESS	ACTRESS	an0054044	Darling	tt0059084	Julie Christie	Julie Christie	nm0001046	True	Diana Scott
-38	1965	Acting	ACTRESS	ACTRESS	an0054046	The Collector	tt0059043	Samantha Eggar	Samantha Eggar	nm0002058		Miranda Grey
-38	1965	Acting	ACTRESS	ACTRESS	an0054047	A Patch of Blue	tt0059573	Elizabeth Hartman	Elizabeth Hartman	nm0366946		Selina D'Arcey
-38	1965	Acting	ACTRESS	ACTRESS	an0054048	Ship of Fools	tt0059712	Simone Signoret	Simone Signoret	nm0797531		La Condessa
+38	1965	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054045	The Sound of Music	tt0059742	Julie Andrews	Julie Andrews	nm0000267		Maria
+38	1965	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054044	Darling	tt0059084	Julie Christie	Julie Christie	nm0001046	True	Diana Scott
+38	1965	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054046	The Collector	tt0059043	Samantha Eggar	Samantha Eggar	nm0002058		Miranda Grey
+38	1965	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054047	A Patch of Blue	tt0059573	Elizabeth Hartman	Elizabeth Hartman	nm0366946		Selina D'Arcey
+38	1965	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054048	Ship of Fools	tt0059712	Simone Signoret	Simone Signoret	nm0797531		La Condessa
 38	1965	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054055	Inside Daisy Clover	tt0059314	Ruth Gordon	Ruth Gordon	nm0002106		The Dealer
 38	1965	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054056	Othello	tt0059555	Joyce Redman	Joyce Redman	nm0715010		Emilia
 38	1965	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054057	Othello	tt0059555	Maggie Smith	Maggie Smith	nm0001749		Desdemona
@@ -4525,11 +4525,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 38	1965	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054138	Skaterdater	tt0059725	Marshal Backlar and Noel Black, Producers	Marshal Backlar, Noel Black	nm0045677,nm0085457
 38	1965	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054139	Snow	tt0059731	Edgar Anstey, Producer	Edgar Anstey	nm0030693
 38	1965	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054140	Time Piece	tt0059807	Jim Henson, Producer	Jim Henson	nm0001345
-38	1965	Production	SOUND	SOUND	an0054105	The Agony and the Ecstasy	tt0058886	20th Century-Fox Studio Sound Department, James P. Corcoran, Sound Director	20th Century-Fox, James P. Corcoran	co0028775,nm0179331
-38	1965	Production	SOUND	SOUND	an0054106	Doctor Zhivago	tt0059113	Metro-Goldwyn-Mayer British Studio Sound Department, A. W. Watkins, Sound Director; and Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer British, A. W. Watkins, Metro-Goldwyn-Mayer, Franklin E. Milton	co0006604,nm0914249,co0007143,nm0590665
-38	1965	Production	SOUND	SOUND	an0054107	The Great Race	tt0059243	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
-38	1965	Production	SOUND	SOUND	an0054108	Shenandoah	tt0059711	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
-38	1965	Production	SOUND	SOUND	an0054104	The Sound of Music	tt0059742	20th Century-Fox Studio Sound Department, James P. Corcoran, Sound Director; and Todd-AO Sound Department, Fred Hynes, Sound Director	20th Century-Fox, James P. Corcoran, Todd-AO, Fred Hynes	co0028775,nm0179331,co0016792,nm0405261	True
+38	1965	Production	SOUND MIXING	SOUND	an0054105	The Agony and the Ecstasy	tt0058886	20th Century-Fox Studio Sound Department, James P. Corcoran, Sound Director	20th Century-Fox, James P. Corcoran	co0028775,nm0179331
+38	1965	Production	SOUND MIXING	SOUND	an0054106	Doctor Zhivago	tt0059113	Metro-Goldwyn-Mayer British Studio Sound Department, A. W. Watkins, Sound Director; and Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer British, A. W. Watkins, Metro-Goldwyn-Mayer, Franklin E. Milton	co0006604,nm0914249,co0007143,nm0590665
+38	1965	Production	SOUND MIXING	SOUND	an0054107	The Great Race	tt0059243	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
+38	1965	Production	SOUND MIXING	SOUND	an0054108	Shenandoah	tt0059711	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
+38	1965	Production	SOUND MIXING	SOUND	an0054104	The Sound of Music	tt0059742	20th Century-Fox Studio Sound Department, James P. Corcoran, Sound Director; and Todd-AO Sound Department, Fred Hynes, Sound Director	20th Century-Fox, James P. Corcoran, Todd-AO, Fred Hynes	co0028775,nm0179331,co0016792,nm0405261	True
 38	1965	Production	SOUND EDITING	SOUND EFFECTS	an0054116	The Great Race	tt0059243	Tregoweth Brown	Tregoweth Brown	nm0114830	True
 38	1965	Production	SOUND EDITING	SOUND EFFECTS	an0054117	Von Ryan's Express	tt0059885	Walter A. Rossi	Walter A. Rossi	nm0744346
 38	1965	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0054115	The Greatest Story Ever Told	tt0059245	J. McMillan Johnson	J. McMillan Johnson	nm0425262
@@ -4549,21 +4549,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 38	1965	Special	IRVING G. THALBERG MEMORIAL AWARD	IRVING G. THALBERG MEMORIAL AWARD	an0047998			William Wyler	William Wyler	nm0943758	True
 38	1965	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					ARTHUR J. HATCH		True	Lighting		To ARTHUR J. HATCH of the Strong Electric Corporation subsidiary of General Precision Equipment Corporation, for the design and development of an Air Blown Carbon Arc Projection Lamp.
 38	1965	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Stefan Kudelski		True	Sound		To STEFAN KUDELSKI for the design and development of the Nagra portable 1/4 inch tape recording system for motion picture sound recording.
-39	1966	Acting	ACTOR	ACTOR	an0054405	The Russians Are Coming The Russians Are Coming	tt0060921	Alan Arkin	Alan Arkin	nm0000273		Rozanov
-39	1966	Acting	ACTOR	ACTOR	an0054406	Who's Afraid of Virginia Woolf?	tt0061184	Richard Burton	Richard Burton	nm0000009		George
-39	1966	Acting	ACTOR	ACTOR	an0054407	Alfie	tt0060086	Michael Caine	Michael Caine	nm0000323		Alfie
-39	1966	Acting	ACTOR	ACTOR	an0054408	The Sand Pebbles	tt0060934	Steve McQueen	Steve McQueen	nm0000537		Jake Holman
-39	1966	Acting	ACTOR	ACTOR	an0054404	A Man for All Seasons	tt0060665	Paul Scofield	Paul Scofield	nm0006890	True	Sir Thomas More
+39	1966	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054405	The Russians Are Coming The Russians Are Coming	tt0060921	Alan Arkin	Alan Arkin	nm0000273		Rozanov
+39	1966	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054406	Who's Afraid of Virginia Woolf?	tt0061184	Richard Burton	Richard Burton	nm0000009		George
+39	1966	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054407	Alfie	tt0060086	Michael Caine	Michael Caine	nm0000323		Alfie
+39	1966	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054408	The Sand Pebbles	tt0060934	Steve McQueen	Steve McQueen	nm0000537		Jake Holman
+39	1966	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0054404	A Man for All Seasons	tt0060665	Paul Scofield	Paul Scofield	nm0006890	True	Sir Thomas More
 39	1966	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054415	The Sand Pebbles	tt0060934	Mako	Mako	nm0538683		Po-Han
 39	1966	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054416	Georgy Girl	tt0060453	James Mason	James Mason	nm0000051		James Leamington
 39	1966	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054414	The Fortune Cookie	tt0060424	Walter Matthau	Walter Matthau	nm0000527	True	Willie Gingrich
 39	1966	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054417	Who's Afraid of Virginia Woolf?	tt0061184	George Segal	George Segal	nm0001719		Nick
 39	1966	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0054418	A Man for All Seasons	tt0060665	Robert Shaw	Robert Shaw	nm0001727		King Henry VIII
-39	1966	Acting	ACTRESS	ACTRESS	an0054410	A Man and a Woman	tt0061138	Anouk Aimee	Anouk Aimee	nm0000733		Anne Gauthier
-39	1966	Acting	ACTRESS	ACTRESS	an0054411	The Shop on Main Street	tt0059527	Ida Kaminska	Ida Kaminska	nm0436706		Rozalie Lautmanova
-39	1966	Acting	ACTRESS	ACTRESS	an0054412	Georgy Girl	tt0060453	Lynn Redgrave	Lynn Redgrave	nm0001655		Georgy Parkin
-39	1966	Acting	ACTRESS	ACTRESS	an0054413	Morgan!	tt0060714	Vanessa Redgrave	Vanessa Redgrave	nm0000603		Leonie Delt
-39	1966	Acting	ACTRESS	ACTRESS	an0054409	Who's Afraid of Virginia Woolf?	tt0061184	Elizabeth Taylor	Elizabeth Taylor	nm0000072	True	Martha
+39	1966	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054410	A Man and a Woman	tt0061138	Anouk Aimee	Anouk Aimee	nm0000733		Anne Gauthier
+39	1966	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054411	The Shop on Main Street	tt0059527	Ida Kaminska	Ida Kaminska	nm0436706		Rozalie Lautmanova
+39	1966	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054412	Georgy Girl	tt0060453	Lynn Redgrave	Lynn Redgrave	nm0001655		Georgy Parkin
+39	1966	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054413	Morgan!	tt0060714	Vanessa Redgrave	Vanessa Redgrave	nm0000603		Leonie Delt
+39	1966	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0054409	Who's Afraid of Virginia Woolf?	tt0061184	Elizabeth Taylor	Elizabeth Taylor	nm0000072	True	Martha
 39	1966	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054419	Who's Afraid of Virginia Woolf?	tt0061184	Sandy Dennis	Sandy Dennis	nm0006800	True	Honey
 39	1966	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054420	A Man for All Seasons	tt0060665	Wendy Hiller	Wendy Hiller	nm0384908		Alice More
 39	1966	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0054421	Hawaii	tt0060491	Jocelyne Lagarde	Jocelyne Lagarde	nm0481139		Malama
@@ -4650,11 +4650,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 39	1966	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054502	Turkey the Bridge	tt0061128	Derek Williams, Producer	Derek Williams	nm0930426
 39	1966	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054501	Wild Wings	tt0061192	Edgar Anstey, Producer	Edgar Anstey	nm0030693	True
 39	1966	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054503	The Winning Strain	tt0061200	Leslie Winik, Producer	Leslie Winik	nm0935119
-39	1966	Production	SOUND	SOUND	an0054470	Gambit	tt0060445	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
-39	1966	Production	SOUND	SOUND	an0054469	Grand Prix	tt0060472	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665	True
-39	1966	Production	SOUND	SOUND	an0054471	Hawaii	tt0060491	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
-39	1966	Production	SOUND	SOUND	an0054472	The Sand Pebbles	tt0060934	20th Century-Fox Studio Sound Department, James P. Corcoran, Sound Director	20th Century-Fox, James P. Corcoran	co0028775,nm0179331
-39	1966	Production	SOUND	SOUND	an0054473	Who's Afraid of Virginia Woolf?	tt0061184	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
+39	1966	Production	SOUND MIXING	SOUND	an0054470	Gambit	tt0060445	Universal City Studio Sound Department, Waldon O. Watson, Sound Director	Universal City, Waldon O. Watson	co0005073,nm0910592
+39	1966	Production	SOUND MIXING	SOUND	an0054469	Grand Prix	tt0060472	Metro-Goldwyn-Mayer Studio Sound Department, Franklin E. Milton, Sound Director	Metro-Goldwyn-Mayer, Franklin E. Milton	co0007143,nm0590665	True
+39	1966	Production	SOUND MIXING	SOUND	an0054471	Hawaii	tt0060491	Samuel Goldwyn Studio Sound Department, Gordon E. Sawyer, Sound Director	Samuel Goldwyn, Gordon E. Sawyer	co0058013,nm0768167
+39	1966	Production	SOUND MIXING	SOUND	an0054472	The Sand Pebbles	tt0060934	20th Century-Fox Studio Sound Department, James P. Corcoran, Sound Director	20th Century-Fox, James P. Corcoran	co0028775,nm0179331
+39	1966	Production	SOUND MIXING	SOUND	an0054473	Who's Afraid of Virginia Woolf?	tt0061184	Warner Bros. Studio Sound Department, George R. Groves, Sound Director	Warner Bros., George R. Groves	co0080422,nm0344060
 39	1966	Production	SOUND EDITING	SOUND EFFECTS	an0054482	Fantastic Voyage	tt0060397	Walter Rossi	Walter Rossi	nm0744346
 39	1966	Production	SOUND EDITING	SOUND EFFECTS	an0054481	Grand Prix	tt0060472	Gordon Daniel	Gordon Daniel	nm0199635	True
 39	1966	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0054479	Fantastic Voyage	tt0060397	Art Cruickshank	Art Cruickshank	nm0189973	True
@@ -4678,21 +4678,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 39	1966	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Panavision INCORPORATED		True	Stage Operations		To PANAVISION, INCORPORATED, for the design of the Panatron Power Inverter and its application to motion picture camera operation.
 39	1966	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0047675				Carroll Knudson	nm1075094	True	Editorial		To CARROLL KNUDSON for the production of a Composer's Manual for Motion Picture Music Synchronization.
 39	1966	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0047676				Ruby Raksin	nm0707650	True	Editorial		To RUBY RAKSIN for the production of a Composer's Manual for Motion Picture Music Synchronization.
-40	1967	Acting	ACTOR	ACTOR	an0048772	Bonnie and Clyde	tt0061418	Warren Beatty	Warren Beatty	nm0000886		Clyde Barrow
-40	1967	Acting	ACTOR	ACTOR	an0048773	The Graduate	tt0061722	Dustin Hoffman	Dustin Hoffman	nm0000163		Ben Braddock
-40	1967	Acting	ACTOR	ACTOR	an0048774	Cool Hand Luke	tt0061512	Paul Newman	Paul Newman	nm0000056		Luke Jackson
-40	1967	Acting	ACTOR	ACTOR	an0048771	In the Heat of the Night	tt0061811	Rod Steiger	Rod Steiger	nm0001768	True	Police Chief Bill Gillespie
-40	1967	Acting	ACTOR	ACTOR	an0048775	Guess Who's Coming to Dinner	tt0061735	Spencer Tracy	Spencer Tracy	nm0000075		Matt Drayton
+40	1967	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048772	Bonnie and Clyde	tt0061418	Warren Beatty	Warren Beatty	nm0000886		Clyde Barrow
+40	1967	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048773	The Graduate	tt0061722	Dustin Hoffman	Dustin Hoffman	nm0000163		Ben Braddock
+40	1967	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048774	Cool Hand Luke	tt0061512	Paul Newman	Paul Newman	nm0000056		Luke Jackson
+40	1967	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048771	In the Heat of the Night	tt0061811	Rod Steiger	Rod Steiger	nm0001768	True	Police Chief Bill Gillespie
+40	1967	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0048775	Guess Who's Coming to Dinner	tt0061735	Spencer Tracy	Spencer Tracy	nm0000075		Matt Drayton
 40	1967	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048782	The Dirty Dozen	tt0061578	John Cassavetes	John Cassavetes	nm0001023		Victor Franko
 40	1967	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048783	Bonnie and Clyde	tt0061418	Gene Hackman	Gene Hackman	nm0000432		Buck Barrow
 40	1967	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048784	Guess Who's Coming to Dinner	tt0061735	Cecil Kellaway	Cecil Kellaway	nm0445523		Monsignor Ryan
 40	1967	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048781	Cool Hand Luke	tt0061512	George Kennedy	George Kennedy	nm0001421	True	Dragline
 40	1967	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0048785	Bonnie and Clyde	tt0061418	Michael J. Pollard	Michael J. Pollard	nm0689488		C.W. Moss
-40	1967	Acting	ACTRESS	ACTRESS	an0048777	The Graduate	tt0061722	Anne Bancroft	Anne Bancroft	nm0000843		Mrs. Robinson
-40	1967	Acting	ACTRESS	ACTRESS	an0048778	Bonnie and Clyde	tt0061418	Faye Dunaway	Faye Dunaway	nm0001159		Bonnie Parker
-40	1967	Acting	ACTRESS	ACTRESS	an0048779	The Whisperers	tt0061180	Dame Edith Evans	Dame Edith Evans	nm0262725		Mrs. Ross
-40	1967	Acting	ACTRESS	ACTRESS	an0048780	Wait until Dark	tt0062467	Audrey Hepburn	Audrey Hepburn	nm0000030		Susy Hendrix
-40	1967	Acting	ACTRESS	ACTRESS	an0048776	Guess Who's Coming to Dinner	tt0061735	Katharine Hepburn	Katharine Hepburn	nm0000031	True	Christina Drayton
+40	1967	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048777	The Graduate	tt0061722	Anne Bancroft	Anne Bancroft	nm0000843		Mrs. Robinson
+40	1967	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048778	Bonnie and Clyde	tt0061418	Faye Dunaway	Faye Dunaway	nm0001159		Bonnie Parker
+40	1967	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048779	The Whisperers	tt0061180	Dame Edith Evans	Dame Edith Evans	nm0262725		Mrs. Ross
+40	1967	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048780	Wait until Dark	tt0062467	Audrey Hepburn	Audrey Hepburn	nm0000030		Susy Hendrix
+40	1967	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0048776	Guess Who's Coming to Dinner	tt0061735	Katharine Hepburn	Katharine Hepburn	nm0000031	True	Christina Drayton
 40	1967	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048787	Thoroughly Modern Millie	tt0062362	Carol Channing	Carol Channing	nm0151919		Muzzy Van Hossmere
 40	1967	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048788	Barefoot in the Park	tt0061385	Mildred Natwick	Mildred Natwick	nm0622450		Mrs. Ethel Banks
 40	1967	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0048786	Bonnie and Clyde	tt0061418	Estelle Parsons	Estelle Parsons	nm0663820	True	Blanche Barrow
@@ -4765,11 +4765,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 40	1967	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048853	A Place to Stand	tt0062131	Christopher Chapman, Producer	Christopher Chapman	nm0152326	True
 40	1967	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048855	Sky over Holland	tt0062278	John Ferno, Producer	John Ferno	nm0273142
 40	1967	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0048856	Stop, Look and Listen	tt0062307	Len Janson and Chuck Menville, Producers	Len Janson, Chuck Menville	nm0418116,nm0579912
-40	1967	Production	SOUND	SOUND	an0048822	Camelot	tt0061439	Warner Bros.-Seven Arts Studio Sound Department	Warner Bros., Seven Arts	co0080422,?
-40	1967	Production	SOUND	SOUND	an0048823	The Dirty Dozen	tt0061578	Metro-Goldwyn-Mayer Studio Sound Department	Metro-Goldwyn-Mayer	co0007143
-40	1967	Production	SOUND	SOUND	an0048824	Doctor Dolittle	tt0061584	20th Century-Fox Studio Sound Department	20th Century-Fox	co0028775
-40	1967	Production	SOUND	SOUND	an0048821	In the Heat of the Night	tt0061811	Samuel Goldwyn Studio Sound Department	Samuel Goldwyn	co0058013	True
-40	1967	Production	SOUND	SOUND	an0048825	Thoroughly Modern Millie	tt0062362	Universal City Studio Sound Department	Universal City	co0005073
+40	1967	Production	SOUND MIXING	SOUND	an0048822	Camelot	tt0061439	Warner Bros.-Seven Arts Studio Sound Department	Warner Bros., Seven Arts	co0080422,?
+40	1967	Production	SOUND MIXING	SOUND	an0048823	The Dirty Dozen	tt0061578	Metro-Goldwyn-Mayer Studio Sound Department	Metro-Goldwyn-Mayer	co0007143
+40	1967	Production	SOUND MIXING	SOUND	an0048824	Doctor Dolittle	tt0061584	20th Century-Fox Studio Sound Department	20th Century-Fox	co0028775
+40	1967	Production	SOUND MIXING	SOUND	an0048821	In the Heat of the Night	tt0061811	Samuel Goldwyn Studio Sound Department	Samuel Goldwyn	co0058013	True
+40	1967	Production	SOUND MIXING	SOUND	an0048825	Thoroughly Modern Millie	tt0062362	Universal City Studio Sound Department	Universal City	co0005073
 40	1967	Production	SOUND EDITING	SOUND EFFECTS	an0048833	The Dirty Dozen	tt0061578	John Poyner	John Poyner	nm0694713	True
 40	1967	Production	SOUND EDITING	SOUND EFFECTS	an0048834	In the Heat of the Night	tt0061811	James A. Richard	James A. Richard	nm0723821
 40	1967	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0048831	Doctor Dolittle	tt0061584	L. B. Abbott	L. B. Abbott	nm0008004	True
@@ -4791,21 +4791,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 40	1967	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Panavision Incorporated		True	Camera		To PANAVISION, INCORPORATED, for a Variable Speed Motor for Motion Picture Cameras.
 40	1967	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					FRED R. WILSON		True	Sound		To FRED R. WILSON of the Samuel Goldwyn Studio Sound Department for an Audio Level Clamper.
 40	1967	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0054164				Waldon O. Watson, Universal City	nm0910592,co0005073	True	Sound		To WALDON O. WATSON and the UNIVERSAL CITY STUDIO SOUND DEPARTMENT for new concepts in the design of a Music Scoring Stage.
-41	1968	Acting	ACTOR	ACTOR	an0055615	The Heart Is a Lonely Hunter	tt0063050	Alan Arkin	Alan Arkin	nm0000273		Singer
-41	1968	Acting	ACTOR	ACTOR	an0055616	The Fixer	tt0062977	Alan Bates	Alan Bates	nm0000869		Yakov Bok
-41	1968	Acting	ACTOR	ACTOR	an0055617	Oliver!	tt0063385	Ron Moody	Ron Moody	nm0600531		Fagin
-41	1968	Acting	ACTOR	ACTOR	an0055618	The Lion in Winter	tt0063227	Peter O'Toole	Peter O'Toole	nm0000564		King Henry II
-41	1968	Acting	ACTOR	ACTOR	an0055614	Charly	tt0062794	Cliff Robertson	Cliff Robertson	nm0731772	True	Charly Gordon
+41	1968	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055615	The Heart Is a Lonely Hunter	tt0063050	Alan Arkin	Alan Arkin	nm0000273		Singer
+41	1968	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055616	The Fixer	tt0062977	Alan Bates	Alan Bates	nm0000869		Yakov Bok
+41	1968	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055617	Oliver!	tt0063385	Ron Moody	Ron Moody	nm0600531		Fagin
+41	1968	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055618	The Lion in Winter	tt0063227	Peter O'Toole	Peter O'Toole	nm0000564		King Henry II
+41	1968	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055614	Charly	tt0062794	Cliff Robertson	Cliff Robertson	nm0731772	True	Charly Gordon
 41	1968	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055624	The Subject Was Roses	tt0063654	Jack Albertson	Jack Albertson	nm0016776	True	John Cleary
 41	1968	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055625	Faces	tt0062952	Seymour Cassel	Seymour Cassel	nm0001025		Chet
 41	1968	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055626	Star!	tt0063642	Daniel Massey	Daniel Massey	nm0557292		Noel Coward
 41	1968	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055627	Oliver!	tt0063385	Jack Wild	Jack Wild	nm0928349		The Artful Dodger
 41	1968	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055628	The Producers	tt0063462	Gene Wilder	Gene Wilder	nm0000698		Leo Bloom
-41	1968	Acting	ACTRESS	ACTRESS	an0055619	The Lion in Winter	tt0063227	Katharine Hepburn	Katharine Hepburn	nm0000031	True	Queen Eleanor of Aquitaine	NOTE: A tie. The other winner in this category was Barbra Streisand (Funny Girl).
-41	1968	Acting	ACTRESS	ACTRESS	an0055621	The Subject Was Roses	tt0063654	Patricia Neal	Patricia Neal	nm0623658		Nettie Cleary
-41	1968	Acting	ACTRESS	ACTRESS	an0055622	Isadora	tt0063141	Vanessa Redgrave	Vanessa Redgrave	nm0000603		Isadora Duncan
-41	1968	Acting	ACTRESS	ACTRESS	an0055620	Funny Girl	tt0062994	Barbra Streisand	Barbra Streisand	nm0000659	True	Fanny Brice	NOTE: A tie. The other winner in this category was Katharine Hepburn (The Lion in Winter).
-41	1968	Acting	ACTRESS	ACTRESS	an0055623	Rachel, Rachel	tt0063483	Joanne Woodward	Joanne Woodward	nm0940946		Rachel Cameron
+41	1968	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055619	The Lion in Winter	tt0063227	Katharine Hepburn	Katharine Hepburn	nm0000031	True	Queen Eleanor of Aquitaine	NOTE: A tie. The other winner in this category was Barbra Streisand (Funny Girl).
+41	1968	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055621	The Subject Was Roses	tt0063654	Patricia Neal	Patricia Neal	nm0623658		Nettie Cleary
+41	1968	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055622	Isadora	tt0063141	Vanessa Redgrave	Vanessa Redgrave	nm0000603		Isadora Duncan
+41	1968	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055620	Funny Girl	tt0062994	Barbra Streisand	Barbra Streisand	nm0000659	True	Fanny Brice	NOTE: A tie. The other winner in this category was Katharine Hepburn (The Lion in Winter).
+41	1968	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055623	Rachel, Rachel	tt0063483	Joanne Woodward	Joanne Woodward	nm0940946		Rachel Cameron
 41	1968	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055630	Faces	tt0062952	Lynn Carlin	Lynn Carlin	nm0137524		Maria Forst
 41	1968	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055629	Rosemary's Baby	tt0063522	Ruth Gordon	Ruth Gordon	nm0002106	True	Minnie Castevet
 41	1968	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055631	The Heart Is a Lonely Hunter	tt0063050	Sondra Locke	Sondra Locke	nm0516800		Mick Kelly
@@ -4879,11 +4879,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 41	1968	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055697	Duo	tt0063417	National Film Board of Canada	National Film Board of Canada	co0006414
 41	1968	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055698	Prelude	tt0063454	John Astin, Producer	John Astin	nm0040014
 41	1968	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055695	Robert Kennedy Remembered	tt0063514	Charles Guggenheim, Producer	Charles Guggenheim	nm0346549	True
-41	1968	Production	SOUND	SOUND	an0055665	Bullitt	tt0062765	Warner Bros.-Seven Arts Studio Sound Department	Warner Bros., Seven Arts	co0080422,?
-41	1968	Production	SOUND	SOUND	an0055666	Finian's Rainbow	tt0062974	Warner Bros.-Seven Arts Studio Sound Department	Warner Bros., Seven Arts	co0080422,co0638213
-41	1968	Production	SOUND	SOUND	an0055667	Funny Girl	tt0062994	Columbia Studio Sound Department	Columbia	co0050868
-41	1968	Production	SOUND	SOUND	an0055664	Oliver!	tt0063385	Shepperton Studio Sound Department	Shepperton	co0103344	True
-41	1968	Production	SOUND	SOUND	an0055668	Star!	tt0063642	20th Century-Fox Studio Sound Department	20th Century-Fox	co0028775
+41	1968	Production	SOUND MIXING	SOUND	an0055665	Bullitt	tt0062765	Warner Bros.-Seven Arts Studio Sound Department	Warner Bros., Seven Arts	co0080422,?
+41	1968	Production	SOUND MIXING	SOUND	an0055666	Finian's Rainbow	tt0062974	Warner Bros.-Seven Arts Studio Sound Department	Warner Bros., Seven Arts	co0080422,co0638213
+41	1968	Production	SOUND MIXING	SOUND	an0055667	Funny Girl	tt0062994	Columbia Studio Sound Department	Columbia	co0050868
+41	1968	Production	SOUND MIXING	SOUND	an0055664	Oliver!	tt0063385	Shepperton Studio Sound Department	Shepperton	co0103344	True
+41	1968	Production	SOUND MIXING	SOUND	an0055668	Star!	tt0063642	20th Century-Fox Studio Sound Department	20th Century-Fox	co0028775
 41	1968	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0055675	Ice Station Zebra	tt0063121	Hal Millar, J. McMillan Johnson	Hal Millar, J. McMillan Johnson	nm0587671,nm0425262
 41	1968	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0055674	2001: A Space Odyssey	tt0062622	Stanley Kubrick	Stanley Kubrick	nm0000040	True
 41	1968	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0055639	The Lion in Winter	tt0063227	James Goldman	James Goldman	nm0063953	True
@@ -4910,21 +4910,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 41	1968	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)					Todd-Ao, Mitchell Camera Company		True	Camera		To TODD-AO and MITCHELL CAMERA COMPANY for the design and engineering of the Todd-AO hand-held motion picture camera.
 41	1968	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					CARL W. HAUGE, EDWARD H. REICHARD, E. MICHAEL MEAHL, ROY J. RIDENOUR		True	Laboratory		To CARL W. HAUGE and EDWARD H. REICHARD of Consolidated Film Industries and E. MICHAEL MEAHL and ROY J. RIDENOUR of Ramtronics for engineering an automatic exposure control for printing-machine lamps.
 41	1968	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Eastman Kodak Company, Consolidated Film Industries		True	Film		To EASTMAN KODAK COMPANY for a new direct positive film and to CONSOLIDATED FILM INDUSTRIES for the application of this film to the making of post-production work prints.
-42	1969	Acting	ACTOR	ACTOR	an0056380	Anne of the Thousand Days	tt0064030	Richard Burton	Richard Burton	nm0000009		King Henry VIII
-42	1969	Acting	ACTOR	ACTOR	an0056381	Midnight Cowboy	tt0064665	Dustin Hoffman	Dustin Hoffman	nm0000163		Ratso Rizzo
-42	1969	Acting	ACTOR	ACTOR	an0056382	Goodbye, Mr. Chips	tt0064382	Peter O'Toole	Peter O'Toole	nm0000564		Arthur Chipping
-42	1969	Acting	ACTOR	ACTOR	an0056383	Midnight Cowboy	tt0064665	Jon Voight	Jon Voight	nm0000685		Joe Buck
-42	1969	Acting	ACTOR	ACTOR	an0056379	True Grit	tt0065126	John Wayne	John Wayne	nm0000078	True	Rooster Cogburn
+42	1969	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056380	Anne of the Thousand Days	tt0064030	Richard Burton	Richard Burton	nm0000009		King Henry VIII
+42	1969	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056381	Midnight Cowboy	tt0064665	Dustin Hoffman	Dustin Hoffman	nm0000163		Ratso Rizzo
+42	1969	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056382	Goodbye, Mr. Chips	tt0064382	Peter O'Toole	Peter O'Toole	nm0000564		Arthur Chipping
+42	1969	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056383	Midnight Cowboy	tt0064665	Jon Voight	Jon Voight	nm0000685		Joe Buck
+42	1969	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056379	True Grit	tt0065126	John Wayne	John Wayne	nm0000078	True	Rooster Cogburn
 42	1969	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056390	The Reivers	tt0064886	Rupert Crosse	Rupert Crosse	nm0189313		Ned McCaslin
 42	1969	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056391	Bob & Carol & Ted & Alice	tt0064100	Elliott Gould	Elliott Gould	nm0001285		Ted Henderson
 42	1969	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056392	Easy Rider	tt0064276	Jack Nicholson	Jack Nicholson	nm0000197		George Hanson
 42	1969	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056393	Anne of the Thousand Days	tt0064030	Anthony Quayle	Anthony Quayle	nm0703033		Cardinal Wolsey
 42	1969	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056389	They Shoot Horses, Don't They?	tt0065088	Gig Young	Gig Young	nm0949574	True	Rocky
-42	1969	Acting	ACTRESS	ACTRESS	an0056385	Anne of the Thousand Days	tt0064030	Genevieve Bujold	Genevieve Bujold	nm0000991		Anne Boleyn
-42	1969	Acting	ACTRESS	ACTRESS	an0056386	They Shoot Horses, Don't They?	tt0065088	Jane Fonda	Jane Fonda	nm0000404		Gloria Beatty
-42	1969	Acting	ACTRESS	ACTRESS	an0056387	The Sterile Cuckoo	tt0065037	Liza Minnelli	Liza Minnelli	nm0591485		Pookie Adams
-42	1969	Acting	ACTRESS	ACTRESS	an0056388	The Happy Ending	tt0064405	Jean Simmons	Jean Simmons	nm0001739		Mary Wilson
-42	1969	Acting	ACTRESS	ACTRESS	an0056384	The Prime of Miss Jean Brodie	tt0064840	Maggie Smith	Maggie Smith	nm0001749	True	Miss Jean Brodie
+42	1969	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056385	Anne of the Thousand Days	tt0064030	Genevieve Bujold	Genevieve Bujold	nm0000991		Anne Boleyn
+42	1969	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056386	They Shoot Horses, Don't They?	tt0065088	Jane Fonda	Jane Fonda	nm0000404		Gloria Beatty
+42	1969	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056387	The Sterile Cuckoo	tt0065037	Liza Minnelli	Liza Minnelli	nm0591485		Pookie Adams
+42	1969	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056388	The Happy Ending	tt0064405	Jean Simmons	Jean Simmons	nm0001739		Mary Wilson
+42	1969	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056384	The Prime of Miss Jean Brodie	tt0064840	Maggie Smith	Maggie Smith	nm0001749	True	Miss Jean Brodie
 42	1969	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056395	Last Summer	tt0064573	Catherine Burns	Catherine Burns	nm0122610		Rhoda
 42	1969	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056396	Bob & Carol & Ted & Alice	tt0064100	Dyan Cannon	Dyan Cannon	nm0001007		Alice Henderson
 42	1969	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056394	Cactus Flower	tt0064117	Goldie Hawn	Goldie Hawn	nm0000443	True	Toni Simmons
@@ -4996,11 +4996,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 42	1969	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0056460	Blake	tt0064094	Doug Jackson, Producer	Doug Jackson	nm0413465
 42	1969	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0056459	The Magic Machines	tt0064623	Joan Keller Stern, Producer	Joan Keller Stern	nm0445678	True
 42	1969	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0056461	People Soup	tt0064799	Marc Merson, Producer	Marc Merson	nm0581516
-42	1969	Production	SOUND	SOUND	an0056430	Anne of the Thousand Days	tt0064030	John Aldred	John Aldred	nm0017640
-42	1969	Production	SOUND	SOUND	an0056431	Butch Cassidy and the Sundance Kid	tt0064115	William Edmondson, David Dockendorf	William Edmondson, David Dockendorf	nm0249553,nm0229990
-42	1969	Production	SOUND	SOUND	an0056432	Gaily, Gaily	tt0064357	Robert Martin, Clem Portman	Robert Martin, Clem Portman	nm0552980,nm0692436
-42	1969	Production	SOUND	SOUND	an0056429	Hello, Dolly!	tt0064418	Jack Solomon, Murray Spivack	Jack Solomon, Murray Spivack	nm0813349,nm0819203	True
-42	1969	Production	SOUND	SOUND	an0056433	Marooned	tt0064639	Les Fresholtz, Arthur Piantadosi	Les Fresholtz, Arthur Piantadosi	nm0294370,nm0681250
+42	1969	Production	SOUND MIXING	SOUND	an0056430	Anne of the Thousand Days	tt0064030	John Aldred	John Aldred	nm0017640
+42	1969	Production	SOUND MIXING	SOUND	an0056431	Butch Cassidy and the Sundance Kid	tt0064115	William Edmondson, David Dockendorf	William Edmondson, David Dockendorf	nm0249553,nm0229990
+42	1969	Production	SOUND MIXING	SOUND	an0056432	Gaily, Gaily	tt0064357	Robert Martin, Clem Portman	Robert Martin, Clem Portman	nm0552980,nm0692436
+42	1969	Production	SOUND MIXING	SOUND	an0056429	Hello, Dolly!	tt0064418	Jack Solomon, Murray Spivack	Jack Solomon, Murray Spivack	nm0813349,nm0819203	True
+42	1969	Production	SOUND MIXING	SOUND	an0056433	Marooned	tt0064639	Les Fresholtz, Arthur Piantadosi	Les Fresholtz, Arthur Piantadosi	nm0294370,nm0681250
 42	1969	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0056440	Krakatoa, East of Java	tt0064555	Eugene Lourie, Alex Weldon	Eugene Lourie, Alex Weldon	nm0522123,nm0919708
 42	1969	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0056439	Marooned	tt0064639	Robbie Robertson	Robbie Robertson	nm0733045	True
 42	1969	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0056405	Anne of the Thousand Days	tt0064030	Screenplay by John Hale, Bridget Boland; Adaptation by Richard Sokolove	John Hale, Bridget Boland, Richard Sokolove	nm0354942,nm0092658,nm0812501
@@ -5022,21 +5022,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 42	1969	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0049428				FENTON HAMILTON	nm0357844	True	Lighting		To FENTON HAMILTON of Metro-Goldwyn-Mayer Studios for the concept and engineering of a mobile battery power unit for location lighting.
 42	1969	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Panavision Incorporated		True	Camera		To PANAVISION, INCORPORATED, for the design and development of the Panaspeed Motion Picture Camera Motor.
 42	1969	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					ROBERT M. FLYNN, RUSSELL HESSEY		True	Stage Operations		To ROBERT M. FLYNN and RUSSELL HESSEY of Universal City Studios, Inc. for a machine-gun modification for motion picture photography.
-43	1970	Acting	ACTOR	ACTOR	an0055877	I Never Sang for My Father	tt0065872	Melvyn Douglas	Melvyn Douglas	nm0002048		Tom Garrison
-43	1970	Acting	ACTOR	ACTOR	an0055878	The Great White Hope	tt0065797	James Earl Jones	James Earl Jones	nm0000469		Jack Jefferson
-43	1970	Acting	ACTOR	ACTOR	an0055879	Five Easy Pieces	tt0065724	Jack Nicholson	Jack Nicholson	nm0000197		Robert Eroica Dupea
-43	1970	Acting	ACTOR	ACTOR	an0055880	Love Story	tt0066011	Ryan O'Neal	Ryan O'Neal	nm0641939		Oliver Barrett IV
-43	1970	Acting	ACTOR	ACTOR	an0055876	Patton	tt0066206	George C. Scott	George C. Scott	nm0001715	True	General George S. Patton, Jr.	NOTE: Mr. Scott refused the award.
+43	1970	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055877	I Never Sang for My Father	tt0065872	Melvyn Douglas	Melvyn Douglas	nm0002048		Tom Garrison
+43	1970	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055878	The Great White Hope	tt0065797	James Earl Jones	James Earl Jones	nm0000469		Jack Jefferson
+43	1970	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055879	Five Easy Pieces	tt0065724	Jack Nicholson	Jack Nicholson	nm0000197		Robert Eroica Dupea
+43	1970	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055880	Love Story	tt0066011	Ryan O'Neal	Ryan O'Neal	nm0641939		Oliver Barrett IV
+43	1970	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0055876	Patton	tt0066206	George C. Scott	George C. Scott	nm0001715	True	General George S. Patton, Jr.	NOTE: Mr. Scott refused the award.
 43	1970	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055887	Lovers and Other Strangers	tt0066016	Richard Castellano	Richard Castellano	nm0144710		Frank Vecchio
 43	1970	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055888	Little Big Man	tt0065988	Chief Dan George	Chief Dan George	nm0313381		Old Lodge Skins
 43	1970	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055889	I Never Sang for My Father	tt0065872	Gene Hackman	Gene Hackman	nm0000432		Gene Garrison
 43	1970	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055890	Love Story	tt0066011	John Marley	John Marley	nm0549134		Phil Cavilleri
 43	1970	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0055886	Ryan's Daughter	tt0066319	John Mills	John Mills	nm0590055	True	Michael
-43	1970	Acting	ACTRESS	ACTRESS	an0055882	The Great White Hope	tt0065797	Jane Alexander	Jane Alexander	nm0000737		Eleanor Bachman
-43	1970	Acting	ACTRESS	ACTRESS	an0055881	Women in Love	tt0066579	Glenda Jackson	Glenda Jackson	nm0413559	True	Gudrun Brangwen
-43	1970	Acting	ACTRESS	ACTRESS	an0055883	Love Story	tt0066011	Ali MacGraw	Ali MacGraw	nm0532298		Jenny Cavilleri
-43	1970	Acting	ACTRESS	ACTRESS	an0055884	Ryan's Daughter	tt0066319	Sarah Miles	Sarah Miles	nm0587234		Rosy Ryan
-43	1970	Acting	ACTRESS	ACTRESS	an0055885	Diary of a Mad Housewife	tt0065636	Carrie Snodgress	Carrie Snodgress	nm0811202		Tina Balser
+43	1970	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055882	The Great White Hope	tt0065797	Jane Alexander	Jane Alexander	nm0000737		Eleanor Bachman
+43	1970	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055881	Women in Love	tt0066579	Glenda Jackson	Glenda Jackson	nm0413559	True	Gudrun Brangwen
+43	1970	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055883	Love Story	tt0066011	Ali MacGraw	Ali MacGraw	nm0532298		Jenny Cavilleri
+43	1970	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055884	Ryan's Daughter	tt0066319	Sarah Miles	Sarah Miles	nm0587234		Rosy Ryan
+43	1970	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0055885	Diary of a Mad Housewife	tt0065636	Carrie Snodgress	Carrie Snodgress	nm0811202		Tina Balser
 43	1970	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055892	Five Easy Pieces	tt0065724	Karen Black	Karen Black	nm0000947		Rayette Dipesto
 43	1970	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055893	The Landlord	tt0065963	Lee Grant	Lee Grant	nm0335519		Mrs. Enders
 43	1970	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0055891	Airport	tt0065377	Helen Hayes	Helen Hayes	nm0371040	True	Ada Quonsett
@@ -5108,11 +5108,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 43	1970	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055956	The Resurrection of Broncho Billy	tt0066294	John Longenecker, Producer	John Longenecker	nm0519290	True
 43	1970	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055957	Shut Up...I'm Crying	tt0066376	Robert Siegler, Producer	Robert Siegler	nm0797088
 43	1970	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0055958	Sticky My Fingers...Fleet My Feet	tt0066406	John Hancock, Producer	John Hancock	nm0359386
-43	1970	Production	SOUND	SOUND	an0055927	Airport	tt0065377	Ronald Pierce, David Moriarty	Ronald Pierce, David Moriarty	nm0682463,nm0605341
-43	1970	Production	SOUND	SOUND	an0055926	Patton	tt0066206	Douglas Williams, Don Bassman	Douglas Williams, Don Bassman	nm0930491,nm0060318	True
-43	1970	Production	SOUND	SOUND	an0055928	Ryan's Daughter	tt0066319	Gordon K. McCallum, John Bramall	Gordon K. McCallum, John Bramall	nm0564730,nm0104171
-43	1970	Production	SOUND	SOUND	an0055929	Tora! Tora! Tora!	tt0066473	Murray Spivack, Herman Lewis	Murray Spivack, Herman Lewis	nm0819203,nm0507266
-43	1970	Production	SOUND	SOUND	an0055930	Woodstock	tt0066580	Dan Wallin, Larry Johnson	Dan Wallin, Larry Johnson	nm0909163,nm0425588
+43	1970	Production	SOUND MIXING	SOUND	an0055927	Airport	tt0065377	Ronald Pierce, David Moriarty	Ronald Pierce, David Moriarty	nm0682463,nm0605341
+43	1970	Production	SOUND MIXING	SOUND	an0055926	Patton	tt0066206	Douglas Williams, Don Bassman	Douglas Williams, Don Bassman	nm0930491,nm0060318	True
+43	1970	Production	SOUND MIXING	SOUND	an0055928	Ryan's Daughter	tt0066319	Gordon K. McCallum, John Bramall	Gordon K. McCallum, John Bramall	nm0564730,nm0104171
+43	1970	Production	SOUND MIXING	SOUND	an0055929	Tora! Tora! Tora!	tt0066473	Murray Spivack, Herman Lewis	Murray Spivack, Herman Lewis	nm0819203,nm0507266
+43	1970	Production	SOUND MIXING	SOUND	an0055930	Woodstock	tt0066580	Dan Wallin, Larry Johnson	Dan Wallin, Larry Johnson	nm0909163,nm0425588
 43	1970	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0055937	Patton	tt0066206	Alex Weldon	Alex Weldon	nm0919708
 43	1970	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0055936	Tora! Tora! Tora!	tt0066473	A. D. Flowers, L. B. Abbott	A. D. Flowers, L. B. Abbott	nm0283166,nm0008004	True
 43	1970	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0055902	Airport	tt0065377	George Seaton	George Seaton	nm0780833
@@ -5134,21 +5134,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 43	1970	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					B. J. Losmandy		True	Sound		To B. J. LOSMANDY for the concept, design and application of micro-miniature solid state amplifier modules used in motion picture recording equipment.
 43	1970	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Eastman Kodak Company, Photo Electronics Corporation		True	Laboratory		To EASTMAN KODAK COMPANY and PHOTO ELECTRONICS CORPORATION for the design and engineering of an improved video color analyzer for motion picture laboratories.
 43	1970	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Electro Sound Incorporated		True	Sound		To ELECTRO SOUND INCORPORATED for the design and introduction of the Series 8000 Sound System for motion picture theatres.
-44	1971	Acting	ACTOR	ACTOR	an0056971	Sunday Bloody Sunday	tt0067805	Peter Finch	Peter Finch	nm0002075		Dr. Daniel Hirsh
-44	1971	Acting	ACTOR	ACTOR	an0056970	The French Connection	tt0067116	Gene Hackman	Gene Hackman	nm0000432	True	Jimmy 'Popeye' Doyle
-44	1971	Acting	ACTOR	ACTOR	an0056972	Kotch	tt0067314	Walter Matthau	Walter Matthau	nm0000527		Joseph P. Kotcher
-44	1971	Acting	ACTOR	ACTOR	an0056973	The Hospital	tt0067217	George C. Scott	George C. Scott	nm0001715		Dr. Herbert Bock
-44	1971	Acting	ACTOR	ACTOR	an0056974	Fiddler on the Roof	tt0067093	Topol	Topol	nm0867694		Tevye
+44	1971	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056971	Sunday Bloody Sunday	tt0067805	Peter Finch	Peter Finch	nm0002075		Dr. Daniel Hirsh
+44	1971	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056970	The French Connection	tt0067116	Gene Hackman	Gene Hackman	nm0000432	True	Jimmy 'Popeye' Doyle
+44	1971	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056972	Kotch	tt0067314	Walter Matthau	Walter Matthau	nm0000527		Joseph P. Kotcher
+44	1971	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056973	The Hospital	tt0067217	George C. Scott	George C. Scott	nm0001715		Dr. Herbert Bock
+44	1971	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0056974	Fiddler on the Roof	tt0067093	Topol	Topol	nm0867694		Tevye
 44	1971	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056981	The Last Picture Show	tt0067328	Jeff Bridges	Jeff Bridges	nm0000313		Duane Jackson
 44	1971	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056982	Fiddler on the Roof	tt0067093	Leonard Frey	Leonard Frey	nm0294600		Motel
 44	1971	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056983	Sometimes a Great Notion	tt0067774	Richard Jaeckel	Richard Jaeckel	nm0001395		Joe Ben Stamper
 44	1971	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056980	The Last Picture Show	tt0067328	Ben Johnson	Ben Johnson	nm0424565	True	Sam the Lion
 44	1971	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0056984	The French Connection	tt0067116	Roy Scheider	Roy Scheider	nm0001702		Buddy Russo
-44	1971	Acting	ACTRESS	ACTRESS	an0056976	McCabe & Mrs. Miller	tt0067411	Julie Christie	Julie Christie	nm0001046		Mrs. Constance Miller
-44	1971	Acting	ACTRESS	ACTRESS	an0056975	Klute	tt0067309	Jane Fonda	Jane Fonda	nm0000404	True	Bree Daniel
-44	1971	Acting	ACTRESS	ACTRESS	an0056977	Sunday Bloody Sunday	tt0067805	Glenda Jackson	Glenda Jackson	nm0413559		Alex Greville
-44	1971	Acting	ACTRESS	ACTRESS	an0056978	Mary, Queen of Scots	tt0067402	Vanessa Redgrave	Vanessa Redgrave	nm0000603		Mary, Queen of Scots
-44	1971	Acting	ACTRESS	ACTRESS	an0056979	Nicholas and Alexandra	tt0067483	Janet Suzman	Janet Suzman	nm0840531		Alexandra
+44	1971	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056976	McCabe & Mrs. Miller	tt0067411	Julie Christie	Julie Christie	nm0001046		Mrs. Constance Miller
+44	1971	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056975	Klute	tt0067309	Jane Fonda	Jane Fonda	nm0000404	True	Bree Daniel
+44	1971	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056977	Sunday Bloody Sunday	tt0067805	Glenda Jackson	Glenda Jackson	nm0413559		Alex Greville
+44	1971	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056978	Mary, Queen of Scots	tt0067402	Vanessa Redgrave	Vanessa Redgrave	nm0000603		Mary, Queen of Scots
+44	1971	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0056979	Nicholas and Alexandra	tt0067483	Janet Suzman	Janet Suzman	nm0840531		Alexandra
 44	1971	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056989	Carnal Knowledge	tt0066892	Ann-Margret	Ann-Margret	nm0000268		Bobbie
 44	1971	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056986	The Last Picture Show	tt0067328	Ellen Burstyn	Ellen Burstyn	nm0000995		Lois Farrow
 44	1971	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0056987	Who Is Harry Kellerman and Why Is He Saying Those Terrible Things about Me?	tt0067980	Barbara Harris	Barbara Harris	nm0364455		Allison
@@ -5220,11 +5220,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 44	1971	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0057051	Good Morning	tt0067152	Denny Evans and Ken Greenwald, Producers	Denny Evans, Ken Greenwald	nm0262706,nm0339241
 44	1971	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0057052	The Rehearsal	tt0067662	Stephen F. Verona, Producer	Stephen F. Verona	nm0894776
 44	1971	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0057050	Sentinels of Silence	tt0067733	Manuel Arango and Robert Amram, Producers	Manuel Arango, Robert Amram	nm0033045,nm0025374	True
-44	1971	Production	SOUND	SOUND	an0057021	Diamonds Are Forever	tt0066995	Gordon K. McCallum, John Mitchell, Alfred J. Overton	Gordon K. McCallum, John Mitchell, Alfred J. Overton	nm0564730,nm0593466,nm0653931
-44	1971	Production	SOUND	SOUND	an0057020	Fiddler on the Roof	tt0067093	Gordon K. McCallum, David Hildyard	Gordon K. McCallum, David Hildyard	nm0564730,nm0383934	True
-44	1971	Production	SOUND	SOUND	an0057022	The French Connection	tt0067116	Theodore Soderberg, Christopher Newman	Theodore Soderberg, Christopher Newman	nm0812029,nm0628039
-44	1971	Production	SOUND	SOUND	an0057023	Kotch	tt0067314	Richard Portman, Jack Solomon	Richard Portman, Jack Solomon	nm0692446,nm0813349
-44	1971	Production	SOUND	SOUND	an0057024	Mary, Queen of Scots	tt0067402	Bob Jones, John Aldred	Bob Jones, John Aldred	nm0427590,nm0017640
+44	1971	Production	SOUND MIXING	SOUND	an0057021	Diamonds Are Forever	tt0066995	Gordon K. McCallum, John Mitchell, Alfred J. Overton	Gordon K. McCallum, John Mitchell, Alfred J. Overton	nm0564730,nm0593466,nm0653931
+44	1971	Production	SOUND MIXING	SOUND	an0057020	Fiddler on the Roof	tt0067093	Gordon K. McCallum, David Hildyard	Gordon K. McCallum, David Hildyard	nm0564730,nm0383934	True
+44	1971	Production	SOUND MIXING	SOUND	an0057022	The French Connection	tt0067116	Theodore Soderberg, Christopher Newman	Theodore Soderberg, Christopher Newman	nm0812029,nm0628039
+44	1971	Production	SOUND MIXING	SOUND	an0057023	Kotch	tt0067314	Richard Portman, Jack Solomon	Richard Portman, Jack Solomon	nm0692446,nm0813349
+44	1971	Production	SOUND MIXING	SOUND	an0057024	Mary, Queen of Scots	tt0067402	Bob Jones, John Aldred	Bob Jones, John Aldred	nm0427590,nm0017640
 44	1971	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0057045	Bedknobs and Broomsticks	tt0066817	Alan Maley, Eustace Lycett, Danny Lee	Alan Maley, Eustace Lycett, Danny Lee	nm0539426,nm0527941,nm0497098	True
 44	1971	Production	VISUAL EFFECTS	SPECIAL VISUAL EFFECTS	an0057046	When Dinosaurs Ruled the Earth	tt0066561	Jim Danforth, Roger Dicken	Jim Danforth, Roger Dicken	nm0199453,nm0225312
 44	1971	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0056996	A Clockwork Orange	tt0066921	Stanley Kubrick	Stanley Kubrick	nm0000040
@@ -5244,21 +5244,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 44	1971	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Robert D. Auguste, Cinema Products Company		True	Camera		To ROBERT D. AUGUSTE and CINEMA PRODUCTS COMPANY for the development and introduction of a new crystal controlled lightweight motor for the 35mm motion picture Arriflex camera.
 44	1971	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					PRODUCERS SERVICE CORPORATION, CONSOLIDATED FILM INDUSTRIES, CINEMA RESEARCH CORPORATION, RESEARCH PRODUCTS INC.		True	Laboratory		To PRODUCERS SERVICE CORPORATION and CONSOLIDATED FILM INDUSTRIES; and to CINEMA RESEARCH CORPORATION and RESEARCH PRODUCTS, INC. for the engineering and implementation of fully automated blow-up motion picture printing systems.
 44	1971	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Cinema Products Company		True	Camera		To CINEMA PRODUCTS COMPANY for a control motor to actuate zoom lenses on motion picture cameras.
-45	1972	Acting	ACTOR	ACTOR	an0053939	The Godfather	tt0068646	Marlon Brando	Marlon Brando	nm0000008	True	Don Vito Corleone	NOTE: Mr. Brando refused the award.
-45	1972	Acting	ACTOR	ACTOR	an0053940	Sleuth	tt0069281	Michael Caine	Michael Caine	nm0000323		Milo Tindale
-45	1972	Acting	ACTOR	ACTOR	an0053941	Sleuth	tt0069281	Laurence Olivier	Laurence Olivier	nm0000059		Andrew Wyke
-45	1972	Acting	ACTOR	ACTOR	an0053942	The Ruling Class	tt0069198	Peter O'Toole	Peter O'Toole	nm0000564		Jack, 14th Earl of Gurney
-45	1972	Acting	ACTOR	ACTOR	an0053943	Sounder	tt0069303	Paul Winfield	Paul Winfield	nm0934902		Nathan Lee Morgan
+45	1972	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053939	The Godfather	tt0068646	Marlon Brando	Marlon Brando	nm0000008	True	Don Vito Corleone	NOTE: Mr. Brando refused the award.
+45	1972	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053940	Sleuth	tt0069281	Michael Caine	Michael Caine	nm0000323		Milo Tindale
+45	1972	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053941	Sleuth	tt0069281	Laurence Olivier	Laurence Olivier	nm0000059		Andrew Wyke
+45	1972	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053942	The Ruling Class	tt0069198	Peter O'Toole	Peter O'Toole	nm0000564		Jack, 14th Earl of Gurney
+45	1972	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053943	Sounder	tt0069303	Paul Winfield	Paul Winfield	nm0934902		Nathan Lee Morgan
 45	1972	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053950	The Heartbreak Kid	tt0068687	Eddie Albert	Eddie Albert	nm0000734		Mr. Corcoran
 45	1972	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053951	The Godfather	tt0068646	James Caan	James Caan	nm0001001		Sonny Corleone
 45	1972	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053952	The Godfather	tt0068646	Robert Duvall	Robert Duvall	nm0000380		Tom Hagen
 45	1972	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053949	Cabaret	tt0068327	Joel Grey	Joel Grey	nm0001297	True	The Master of Ceremonies
 45	1972	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053953	The Godfather	tt0068646	Al Pacino	Al Pacino	nm0000199		Michael Corleone
-45	1972	Acting	ACTRESS	ACTRESS	an0053944	Cabaret	tt0068327	Liza Minnelli	Liza Minnelli	nm0591485	True	Sally Bowles
-45	1972	Acting	ACTRESS	ACTRESS	an0053945	Lady Sings the Blues	tt0068828	Diana Ross	Diana Ross	nm0005384		Billie Holiday
-45	1972	Acting	ACTRESS	ACTRESS	an0053946	Travels with My Aunt	tt0069404	Maggie Smith	Maggie Smith	nm0001749		Aunt Augusta
-45	1972	Acting	ACTRESS	ACTRESS	an0053947	Sounder	tt0069303	Cicely Tyson	Cicely Tyson	nm0001807		Rebecca Morgan
-45	1972	Acting	ACTRESS	ACTRESS	an0053948	The Emigrants	tt0067919	Liv Ullmann	Liv Ullmann	nm0880521		Kristina
+45	1972	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053944	Cabaret	tt0068327	Liza Minnelli	Liza Minnelli	nm0591485	True	Sally Bowles
+45	1972	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053945	Lady Sings the Blues	tt0068828	Diana Ross	Diana Ross	nm0005384		Billie Holiday
+45	1972	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053946	Travels with My Aunt	tt0069404	Maggie Smith	Maggie Smith	nm0001749		Aunt Augusta
+45	1972	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053947	Sounder	tt0069303	Cicely Tyson	Cicely Tyson	nm0001807		Rebecca Morgan
+45	1972	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053948	The Emigrants	tt0067919	Liv Ullmann	Liv Ullmann	nm0880521		Kristina
 45	1972	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053955	The Heartbreak Kid	tt0068687	Jeannie Berlin	Jeannie Berlin	nm0075588		Lila
 45	1972	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053954	Butterflies Are Free	tt0068326	Eileen Heckart	Eileen Heckart	nm0373012	True	Mrs. Baker
 45	1972	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053956	Pete 'n' Tillie	tt0069080	Geraldine Page	Geraldine Page	nm0656183		Gertrude
@@ -5329,11 +5329,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 45	1972	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054017	Frog Story	tt0068614	Ron Satlof and Ray Gideon, Producers	Ron Satlof, Ray Gideon	nm0766191,nm0317279
 45	1972	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054016	Norman Rockwell's World...An American Dream	tt0069020	Richard Barclay, Producer	Richard Barclay	nm0054083	True
 45	1972	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0054018	Solo	tt0069296	David Adams, Producer	David Adams	nm0010892
-45	1972	Production	SOUND	SOUND	an0053990	Butterflies Are Free	tt0068326	Arthur Piantadosi, Charles Knight	Arthur Piantadosi, Charles Knight	nm0681250,nm0460837
-45	1972	Production	SOUND	SOUND	an0053989	Cabaret	tt0068327	Robert Knudson, David Hildyard	Robert Knudson, David Hildyard	nm0461702,nm0383934	True
-45	1972	Production	SOUND	SOUND	an0053991	The Candidate	tt0068334	Richard Portman, Gene Cantamessa	Richard Portman, Gene Cantamessa	nm0692446,nm0134481
-45	1972	Production	SOUND	SOUND	an0053992	The Godfather	tt0068646	Bud Grenzbach, Richard Portman, Christopher Newman	Bud Grenzbach, Richard Portman, Christopher Newman	nm0340311,nm0692446,nm0628039
-45	1972	Production	SOUND	SOUND	an0053993	The Poseidon Adventure	tt0069113	Theodore Soderberg, Herman Lewis	Theodore Soderberg, Herman Lewis	nm0812029,nm0507266
+45	1972	Production	SOUND MIXING	SOUND	an0053990	Butterflies Are Free	tt0068326	Arthur Piantadosi, Charles Knight	Arthur Piantadosi, Charles Knight	nm0681250,nm0460837
+45	1972	Production	SOUND MIXING	SOUND	an0053989	Cabaret	tt0068327	Robert Knudson, David Hildyard	Robert Knudson, David Hildyard	nm0461702,nm0383934	True
+45	1972	Production	SOUND MIXING	SOUND	an0053991	The Candidate	tt0068334	Richard Portman, Gene Cantamessa	Richard Portman, Gene Cantamessa	nm0692446,nm0134481
+45	1972	Production	SOUND MIXING	SOUND	an0053992	The Godfather	tt0068646	Bud Grenzbach, Richard Portman, Christopher Newman	Bud Grenzbach, Richard Portman, Christopher Newman	nm0340311,nm0692446,nm0628039
+45	1972	Production	SOUND MIXING	SOUND	an0053993	The Poseidon Adventure	tt0069113	Theodore Soderberg, Herman Lewis	Theodore Soderberg, Herman Lewis	nm0812029,nm0507266
 45	1972	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0053965	Cabaret	tt0068327	Jay Allen	Jay Allen	nm0696319
 45	1972	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0053966	The Emigrants	tt0067919	Jan Troell, Bengt Forslund	Jan Troell, Bengt Forslund	nm0873296,nm0286873
 45	1972	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0053964	The Godfather	tt0068646	Mario Puzo, Francis Ford Coppola	Mario Puzo, Francis Ford Coppola	nm0701374,nm0000338	True
@@ -5357,21 +5357,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 45	1972	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)	an0051399				JIRO MUKAI, RYUSHO HIROSE, WILTON R. HOLM	?,?,nm0391587	True	Lenses and Filters		To JIRO MUKAI and RYUSHO HIROSE of Canon, Inc., and WILTON R. HOLM of the AMPTP Motion Picture and Television Research Center for development of the Canon Macro Zoom Lens for motion picture photography.
 45	1972	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					PHILIP V. PALMQUIST, LEONARD L. OLSON, FRANK P. CLARK		True	Props		To PHILIP V. PALMQUIST and LEONARD L. OLSON of the 3M Company, and FRANK P. CLARK of the AMPTP Motion Picture and Television Research Center for development of the Nextel simulated blood for motion picture color photography.
 45	1972	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					E. H. GEISSLER, G. M. BERGGREN		True	Projection		To E. H. GEISSLER and G. M. BERGGREN of Wil-Kin Inc., for engineering of the Ultra-Vision Motion Picture Theater Projection System.
-46	1973	Acting	ACTOR	ACTOR	an0050433	Last Tango in Paris	tt0070849	Marlon Brando	Marlon Brando	nm0000008		Paul
-46	1973	Acting	ACTOR	ACTOR	an0050432	Save the Tiger	tt0070640	Jack Lemmon	Jack Lemmon	nm0000493	True	Harry Stoner
-46	1973	Acting	ACTOR	ACTOR	an0050434	The Last Detail	tt0070290	Jack Nicholson	Jack Nicholson	nm0000197		Signalman First Class Buddusky
-46	1973	Acting	ACTOR	ACTOR	an0050435	Serpico	tt0070666	Al Pacino	Al Pacino	nm0000199		Frank Serpico
-46	1973	Acting	ACTOR	ACTOR	an0050436	The Sting	tt0070735	Robert Redford	Robert Redford	nm0000602		Johnny Hooker
+46	1973	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050433	Last Tango in Paris	tt0070849	Marlon Brando	Marlon Brando	nm0000008		Paul
+46	1973	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050432	Save the Tiger	tt0070640	Jack Lemmon	Jack Lemmon	nm0000493	True	Harry Stoner
+46	1973	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050434	The Last Detail	tt0070290	Jack Nicholson	Jack Nicholson	nm0000197		Signalman First Class Buddusky
+46	1973	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050435	Serpico	tt0070666	Al Pacino	Al Pacino	nm0000199		Frank Serpico
+46	1973	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0050436	The Sting	tt0070735	Robert Redford	Robert Redford	nm0000602		Johnny Hooker
 46	1973	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050443	Bang the Drum Slowly	tt0069765	Vincent Gardenia	Vincent Gardenia	nm0306696		Dutch Schnell
 46	1973	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050444	Save the Tiger	tt0070640	Jack Gilford	Jack Gilford	nm0318527		Phil Greene
 46	1973	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050442	The Paper Chase	tt0070509	John Houseman	John Houseman	nm0002144	True	Professor Kingsfield
 46	1973	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050445	The Exorcist	tt0070047	Jason Miller	Jason Miller	nm0588553		Father Damian Karras
 46	1973	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0050446	The Last Detail	tt0070290	Randy Quaid	Randy Quaid	nm0001642		Meadows
-46	1973	Acting	ACTRESS	ACTRESS	an0050438	The Exorcist	tt0070047	Ellen Burstyn	Ellen Burstyn	nm0000995		Chris MacNeil
-46	1973	Acting	ACTRESS	ACTRESS	an0050437	A Touch of Class	tt0070819	Glenda Jackson	Glenda Jackson	nm0413559	True	Vicki Allessio
-46	1973	Acting	ACTRESS	ACTRESS	an0050439	Cinderella Liberty	tt0069883	Marsha Mason	Marsha Mason	nm0556850		Maggie Paul
-46	1973	Acting	ACTRESS	ACTRESS	an0050440	The Way We Were	tt0070903	Barbra Streisand	Barbra Streisand	nm0000659		Katie Morosky
-46	1973	Acting	ACTRESS	ACTRESS	an0050441	Summer Wishes, Winter Dreams	tt0070748	Joanne Woodward	Joanne Woodward	nm0940946		Rita Walden
+46	1973	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050438	The Exorcist	tt0070047	Ellen Burstyn	Ellen Burstyn	nm0000995		Chris MacNeil
+46	1973	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050437	A Touch of Class	tt0070819	Glenda Jackson	Glenda Jackson	nm0413559	True	Vicki Allessio
+46	1973	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050439	Cinderella Liberty	tt0069883	Marsha Mason	Marsha Mason	nm0556850		Maggie Paul
+46	1973	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050440	The Way We Were	tt0070903	Barbra Streisand	Barbra Streisand	nm0000659		Katie Morosky
+46	1973	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0050441	Summer Wishes, Winter Dreams	tt0070748	Joanne Woodward	Joanne Woodward	nm0940946		Rita Walden
 46	1973	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050448	The Exorcist	tt0070047	Linda Blair	Linda Blair	nm0000304		Regan MacNeil
 46	1973	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050449	American Graffiti	tt0069704	Candy Clark	Candy Clark	nm0163748		Debbie
 46	1973	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0050450	Paper Moon	tt0070510	Madeline Kahn	Madeline Kahn	nm0001404		Trixie Delight
@@ -5441,11 +5441,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 46	1973	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0050508	The Bolero	tt0069812	Allan Miller and William Fertik, Producers	Allan Miller, William Fertik	nm5850281,nm0275180	True
 46	1973	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0050509	Clockmaker	tt0069891	Richard Gayer, Producer	Richard Gayer	nm0310860
 46	1973	Title	SHORT FILM (Live Action)	SHORT SUBJECT (Live Action)	an0050510	Life Times Nine	tt0070317	Pen Densham and John Watson, Producers	Pen Densham, John Watson	nm0219720,nm0914709
-46	1973	Production	SOUND	SOUND	an0050483	The Day of the Dolphin	tt0069946	Richard Portman, Lawrence O. Jost	Richard Portman, Lawrence O. Jost	nm0692446,nm0430928
-46	1973	Production	SOUND	SOUND	an0050482	The Exorcist	tt0070047	Robert Knudson, Chris Newman	Robert Knudson, Chris Newman	nm0461702,nm0628039	True
-46	1973	Production	SOUND	SOUND	an0050484	The Paper Chase	tt0070509	Donald O. Mitchell, Lawrence O. Jost	Donald O. Mitchell, Lawrence O. Jost	nm0593290,nm0430928
-46	1973	Production	SOUND	SOUND	an0050485	Paper Moon	tt0070510	Richard Portman, Les Fresholtz	Richard Portman, Les Fresholtz	nm0692446,nm0294370
-46	1973	Production	SOUND	SOUND	an0050486	The Sting	tt0070735	Ronald K. Pierce, Robert Bertrand	Ronald K. Pierce, Robert Bertrand	nm0682463,nm0078418
+46	1973	Production	SOUND MIXING	SOUND	an0050483	The Day of the Dolphin	tt0069946	Richard Portman, Lawrence O. Jost	Richard Portman, Lawrence O. Jost	nm0692446,nm0430928
+46	1973	Production	SOUND MIXING	SOUND	an0050482	The Exorcist	tt0070047	Robert Knudson, Chris Newman	Robert Knudson, Chris Newman	nm0461702,nm0628039	True
+46	1973	Production	SOUND MIXING	SOUND	an0050484	The Paper Chase	tt0070509	Donald O. Mitchell, Lawrence O. Jost	Donald O. Mitchell, Lawrence O. Jost	nm0593290,nm0430928
+46	1973	Production	SOUND MIXING	SOUND	an0050485	Paper Moon	tt0070510	Richard Portman, Les Fresholtz	Richard Portman, Les Fresholtz	nm0692446,nm0294370
+46	1973	Production	SOUND MIXING	SOUND	an0050486	The Sting	tt0070735	Ronald K. Pierce, Robert Bertrand	Ronald K. Pierce, Robert Bertrand	nm0682463,nm0078418
 46	1973	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0050457	The Exorcist	tt0070047	William Peter Blatty	William Peter Blatty	nm0087861	True
 46	1973	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0050458	The Last Detail	tt0070290	Robert Towne	Robert Towne	nm0001801
 46	1973	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0050459	The Paper Chase	tt0070509	James Bridges	James Bridges	nm0108745
@@ -5466,21 +5466,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 46	1973	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0050227				Harold A. Scheib, CLIFFORD H. ELLIS, ROGER W. BANKS	nm3520670,?,?	True	Laboratory		To HAROLD A. SCHEIB, CLIFFORD H. ELLIS and ROGER W. BANKS of Research Products Incorporated for the concept and engineering of the Model 2101 optical printer for motion picture optical effects.
 46	1973	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					Rosco Laboratories Inc.		True	Lenses and Filters		To ROSCO LABORATORIES, INC. for the technical advances and the development of a complete system of light-control materials for motion picture photography.
 46	1973	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					RICHARD H. VETTER		True	Lenses and Filters		To RICHARD H. VETTER of Todd-AO Corporation for the design of an improved anamorphic focusing system for motion picture photography.
-47	1974	Acting	ACTOR	ACTOR	an0053332	Harry and Tonto	tt0071598	Art Carney	Art Carney	nm0138770	True	Harry
-47	1974	Acting	ACTOR	ACTOR	an0053333	Murder on the Orient Express	tt0071877	Albert Finney	Albert Finney	nm0001215		Hercule Poirot
-47	1974	Acting	ACTOR	ACTOR	an0053334	Lenny	tt0071746	Dustin Hoffman	Dustin Hoffman	nm0000163		Lenny Bruce
-47	1974	Acting	ACTOR	ACTOR	an0053335	Chinatown	tt0071315	Jack Nicholson	Jack Nicholson	nm0000197		J. J. Gittes
-47	1974	Acting	ACTOR	ACTOR	an0053336	The Godfather Part II	tt0071562	Al Pacino	Al Pacino	nm0000199		Michael Corleone
+47	1974	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053332	Harry and Tonto	tt0071598	Art Carney	Art Carney	nm0138770	True	Harry
+47	1974	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053333	Murder on the Orient Express	tt0071877	Albert Finney	Albert Finney	nm0001215		Hercule Poirot
+47	1974	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053334	Lenny	tt0071746	Dustin Hoffman	Dustin Hoffman	nm0000163		Lenny Bruce
+47	1974	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053335	Chinatown	tt0071315	Jack Nicholson	Jack Nicholson	nm0000197		J. J. Gittes
+47	1974	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0053336	The Godfather Part II	tt0071562	Al Pacino	Al Pacino	nm0000199		Michael Corleone
 47	1974	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053343	The Towering Inferno	tt0072308	Fred Astaire	Fred Astaire	nm0000001		Harlee Claiborne
 47	1974	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053344	Thunderbolt and Lightfoot	tt0072288	Jeff Bridges	Jeff Bridges	nm0000313		Lightfoot
 47	1974	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053342	The Godfather Part II	tt0071562	Robert De Niro	Robert De Niro	nm0000134	True	Vito Corleone
 47	1974	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053345	The Godfather Part II	tt0071562	Michael V. Gazzo	Michael V. Gazzo	nm0311155		Frankie Pentangeli
 47	1974	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0053346	The Godfather Part II	tt0071562	Lee Strasberg	Lee Strasberg	nm0833448		Hyman Roth
-47	1974	Acting	ACTRESS	ACTRESS	an0053337	Alice Doesn't Live Here Anymore	tt0071115	Ellen Burstyn	Ellen Burstyn	nm0000995	True	Alice Hyatt
-47	1974	Acting	ACTRESS	ACTRESS	an0053338	Claudine	tt0071334	Diahann Carroll	Diahann Carroll	nm0140792		Claudine
-47	1974	Acting	ACTRESS	ACTRESS	an0053339	Chinatown	tt0071315	Faye Dunaway	Faye Dunaway	nm0001159		Evelyn Cross Mulwray
-47	1974	Acting	ACTRESS	ACTRESS	an0053340	Lenny	tt0071746	Valerie Perrine	Valerie Perrine	nm0674781		Honey Bruce
-47	1974	Acting	ACTRESS	ACTRESS	an0053341	A Woman under the Influence	tt0072417	Gena Rowlands	Gena Rowlands	nm0001687		Mabel Longhetti
+47	1974	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053337	Alice Doesn't Live Here Anymore	tt0071115	Ellen Burstyn	Ellen Burstyn	nm0000995	True	Alice Hyatt
+47	1974	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053338	Claudine	tt0071334	Diahann Carroll	Diahann Carroll	nm0140792		Claudine
+47	1974	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053339	Chinatown	tt0071315	Faye Dunaway	Faye Dunaway	nm0001159		Evelyn Cross Mulwray
+47	1974	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053340	Lenny	tt0071746	Valerie Perrine	Valerie Perrine	nm0674781		Honey Bruce
+47	1974	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0053341	A Woman under the Influence	tt0072417	Gena Rowlands	Gena Rowlands	nm0001687		Mabel Longhetti
 47	1974	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053347	Murder on the Orient Express	tt0071877	Ingrid Bergman	Ingrid Bergman	nm0000006	True	Greta Ohlsson
 47	1974	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053348	Day for Night	tt0070460	Valentina Cortese	Valentina Cortese	nm0181305		Severine
 47	1974	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0053349	Blazing Saddles	tt0071230	Madeline Kahn	Madeline Kahn	nm0001404		Lili Von Shtupp
@@ -5554,11 +5554,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 47	1974	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053410	One-Eyed Men Are Kings	tt0071943	Paul Claudon and Edmond Sechan, Producers	Paul Claudon, Edmond Sechan	nm0165263,nm0005895	True
 47	1974	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053413	Planet Ocean	tt0072001	George V. Casey, Producer	George V. Casey	nm0143426
 47	1974	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053414	The Violin	tt0072370	Andrew Welsh and George Pastic, Producers	Andrew Welsh, George Pastic	nm0920518,nm0665005
-47	1974	Production	SOUND	SOUND	an0053383	Chinatown	tt0071315	Bud Grenzbach, Larry Jost	Bud Grenzbach, Larry Jost	nm0340311,nm0430928
-47	1974	Production	SOUND	SOUND	an0053384	The Conversation	tt0071360	Walter Murch, Arthur Rochester	Walter Murch, Arthur Rochester	nm0004555,nm0734053
-47	1974	Production	SOUND	SOUND	an0053382	Earthquake	tt0071455	Ronald Pierce, Melvin Metcalfe, Sr.	Ronald Pierce, Melvin Metcalfe Sr.	nm0682463,nm0582436	True
-47	1974	Production	SOUND	SOUND	an0053385	The Towering Inferno	tt0072308	Theodore Soderberg, Herman Lewis	Theodore Soderberg, Herman Lewis	nm0812029,nm0507266
-47	1974	Production	SOUND	SOUND	an0053386	Young Frankenstein	tt0072431	Richard Portman, Gene Cantamessa	Richard Portman, Gene Cantamessa	nm0692446,nm0134481
+47	1974	Production	SOUND MIXING	SOUND	an0053383	Chinatown	tt0071315	Bud Grenzbach, Larry Jost	Bud Grenzbach, Larry Jost	nm0340311,nm0430928
+47	1974	Production	SOUND MIXING	SOUND	an0053384	The Conversation	tt0071360	Walter Murch, Arthur Rochester	Walter Murch, Arthur Rochester	nm0004555,nm0734053
+47	1974	Production	SOUND MIXING	SOUND	an0053382	Earthquake	tt0071455	Ronald Pierce, Melvin Metcalfe, Sr.	Ronald Pierce, Melvin Metcalfe Sr.	nm0682463,nm0582436	True
+47	1974	Production	SOUND MIXING	SOUND	an0053385	The Towering Inferno	tt0072308	Theodore Soderberg, Herman Lewis	Theodore Soderberg, Herman Lewis	nm0812029,nm0507266
+47	1974	Production	SOUND MIXING	SOUND	an0053386	Young Frankenstein	tt0072431	Richard Portman, Gene Cantamessa	Richard Portman, Gene Cantamessa	nm0692446,nm0134481
 47	1974	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0053358	Alice Doesn't Live Here Anymore	tt0071115	Robert Getchell	Robert Getchell	nm0315205
 47	1974	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0053357	Chinatown	tt0071315	Robert Towne	Robert Towne	nm0001801	True
 47	1974	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0053359	The Conversation	tt0071360	Francis Ford Coppola	Francis Ford Coppola	nm0000338
@@ -5580,21 +5580,21 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 47	1974	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class II)	SCIENTIFIC OR TECHNICAL AWARD (Class II)	an0048118				Waldon O. Watson, Richard J. Stumpf, Robert J. Leonard, Universal City Studios	nm0910592,nm0836231,?,co0005073	True	Sound		To WALDON O. WATSON, RICHARD J. STUMPF, ROBERT J. LEONARD and the UNIVERSAL CITY STUDIOS SOUND DEPARTMENT for the development and engineering of the Sensurround System for motion picture presentation.
 47	1974	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					The Elemack Company		True	Camera Cranes		To THE ELEMACK COMPANY, ROME, ITALY, for the design and development of their Spyder camera dolly.
 47	1974	SciTech	SCIENTIFIC OR TECHNICAL AWARD (Class III)	SCIENTIFIC OR TECHNICAL AWARD (Class III)					LOUIS AMI		True	Stage Operations		To LOUIS AMI of Universal City Studios for the design and construction of a reciprocating camera platform used when photographing special visual effects for motion pictures.
-48	1975	Acting	ACTOR	ACTOR	an0051292	The Sunshine Boys	tt0073766	Walter Matthau	Walter Matthau	nm0000527		Willy Clark
-48	1975	Acting	ACTOR	ACTOR	an0051291	One Flew over the Cuckoo's Nest	tt0073486	Jack Nicholson	Jack Nicholson	nm0000197	True	Randle Patrick McMurphy
-48	1975	Acting	ACTOR	ACTOR	an0051293	Dog Day Afternoon	tt0072890	Al Pacino	Al Pacino	nm0000199		Sonny
-48	1975	Acting	ACTOR	ACTOR	an0051294	The Man in the Glass Booth	tt0073345	Maximilian Schell	Maximilian Schell	nm0001703		Arthur Goldman
-48	1975	Acting	ACTOR	ACTOR	an0051295	Give 'em Hell, Harry!	tt0073053	James Whitmore	James Whitmore	nm0926235		Harry S. Truman
+48	1975	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051292	The Sunshine Boys	tt0073766	Walter Matthau	Walter Matthau	nm0000527		Willy Clark
+48	1975	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051291	One Flew over the Cuckoo's Nest	tt0073486	Jack Nicholson	Jack Nicholson	nm0000197	True	Randle Patrick McMurphy
+48	1975	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051293	Dog Day Afternoon	tt0072890	Al Pacino	Al Pacino	nm0000199		Sonny
+48	1975	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051294	The Man in the Glass Booth	tt0073345	Maximilian Schell	Maximilian Schell	nm0001703		Arthur Goldman
+48	1975	Acting	ACTOR IN A LEADING ROLE	ACTOR	an0051295	Give 'em Hell, Harry!	tt0073053	James Whitmore	James Whitmore	nm0926235		Harry S. Truman
 48	1975	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051301	The Sunshine Boys	tt0073766	George Burns	George Burns	nm0122675	True	Al Lewis
 48	1975	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051302	One Flew over the Cuckoo's Nest	tt0073486	Brad Dourif	Brad Dourif	nm0000374		Billy Bibbit
 48	1975	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051303	The Day of the Locust	tt0072848	Burgess Meredith	Burgess Meredith	nm0580565		Harry
 48	1975	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051304	Dog Day Afternoon	tt0072890	Chris Sarandon	Chris Sarandon	nm0001697		Leon
 48	1975	Acting	ACTOR IN A SUPPORTING ROLE	ACTOR IN A SUPPORTING ROLE	an0051305	Shampoo	tt0073692	Jack Warden	Jack Warden	nm0912001		Lester Carr
-48	1975	Acting	ACTRESS	ACTRESS	an0051297	The Story of Adele H.	tt0073114	Isabelle Adjani	Isabelle Adjani	nm0000254		Adele Hugo
-48	1975	Acting	ACTRESS	ACTRESS	an0051298	Tommy	tt0073812	Ann-Margret	Ann-Margret	nm0000268		Nora Walker Hobbs
-48	1975	Acting	ACTRESS	ACTRESS	an0051296	One Flew over the Cuckoo's Nest	tt0073486	Louise Fletcher	Louise Fletcher	nm0001221	True	Nurse Mildred Ratched
-48	1975	Acting	ACTRESS	ACTRESS	an0051299	Hedda	tt0073098	Glenda Jackson	Glenda Jackson	nm0413559		Hedda Gabler
-48	1975	Acting	ACTRESS	ACTRESS	an0051300	Hester Street	tt0073107	Carol Kane	Carol Kane	nm0001406		Gitl
+48	1975	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051297	The Story of Adele H.	tt0073114	Isabelle Adjani	Isabelle Adjani	nm0000254		Adele Hugo
+48	1975	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051298	Tommy	tt0073812	Ann-Margret	Ann-Margret	nm0000268		Nora Walker Hobbs
+48	1975	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051296	One Flew over the Cuckoo's Nest	tt0073486	Louise Fletcher	Louise Fletcher	nm0001221	True	Nurse Mildred Ratched
+48	1975	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051299	Hedda	tt0073098	Glenda Jackson	Glenda Jackson	nm0413559		Hedda Gabler
+48	1975	Acting	ACTRESS IN A LEADING ROLE	ACTRESS	an0051300	Hester Street	tt0073107	Carol Kane	Carol Kane	nm0001406		Gitl
 48	1975	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051307	Nashville	tt0073440	Ronee Blakley	Ronee Blakley	nm0086867		Barbara Jean
 48	1975	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051306	Shampoo	tt0073692	Lee Grant	Lee Grant	nm0335519	True	Felicia Karpf
 48	1975	Acting	ACTRESS IN A SUPPORTING ROLE	ACTRESS IN A SUPPORTING ROLE	an0051308	Farewell, My Lovely	tt0072973	Sylvia Miles	Sylvia Miles	nm0587249		Mrs. Florian
@@ -5667,11 +5667,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 48	1975	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051370	Dawn Flight	tt0072846	Lawrence M. Lansburgh and Brian Lansburgh, Producers	Lawrence M. Lansburgh, Brian Lansburgh	nm0487047,nm0487045
 48	1975	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051371	A Day in the Life of Bonnie Consolo	tt0072847	Barry Spinello, Producer	Barry Spinello	nm0818911
 48	1975	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051372	Doubletalk	tt0072900	Alan Beattie, Producer	Alan Beattie	nm0064133
-48	1975	Production	SOUND	SOUND	an0051342	Bite the Bullet	tt0072705	Arthur Piantadosi, Les Fresholtz, Richard Tyler, Al Overton, Jr.	Arthur Piantadosi, Les Fresholtz, Richard Tyler, Al Overton Jr.	nm0681250,nm0294370,nm0878889,nm0653929
-48	1975	Production	SOUND	SOUND	an0051343	Funny Lady	tt0073026	Richard Portman, Don MacDougall, Curly Thirlwell, Jack Solomon	Richard Portman, Don MacDougall, Curly Thirlwell, Jack Solomon	nm0692446,nm0532013,nm0858218,nm0813349
-48	1975	Production	SOUND	SOUND	an0051344	The Hindenburg	tt0073113	Leonard Peterson, John A. Bolger, Jr., John Mack, Don K. Sharpless	Leonard Peterson, John A. Bolger Jr., John Mack, Don K. Sharpless	nm0677272,nm0092933,nm0533020,nm0789302
-48	1975	Production	SOUND	SOUND	an0051341	Jaws	tt0073195	Robert L. Hoyt, Roger Heman, Earl Madery, John Carter	Robert L. Hoyt, Roger Heman, Earl Madery, John Carter	nm0398480,nm0375947,nm0531071,nm0141728	True
-48	1975	Production	SOUND	SOUND	an0051345	The Wind and the Lion	tt0073906	Harry W. Tetrick, Aaron Rochin, William McCaughey, Roy Charman	Harry W. Tetrick, Aaron Rochin, William McCaughey, Roy Charman	nm0856555,nm0734099,nm0565477,nm0153335
+48	1975	Production	SOUND MIXING	SOUND	an0051342	Bite the Bullet	tt0072705	Arthur Piantadosi, Les Fresholtz, Richard Tyler, Al Overton, Jr.	Arthur Piantadosi, Les Fresholtz, Richard Tyler, Al Overton Jr.	nm0681250,nm0294370,nm0878889,nm0653929
+48	1975	Production	SOUND MIXING	SOUND	an0051343	Funny Lady	tt0073026	Richard Portman, Don MacDougall, Curly Thirlwell, Jack Solomon	Richard Portman, Don MacDougall, Curly Thirlwell, Jack Solomon	nm0692446,nm0532013,nm0858218,nm0813349
+48	1975	Production	SOUND MIXING	SOUND	an0051344	The Hindenburg	tt0073113	Leonard Peterson, John A. Bolger, Jr., John Mack, Don K. Sharpless	Leonard Peterson, John A. Bolger Jr., John Mack, Don K. Sharpless	nm0677272,nm0092933,nm0533020,nm0789302
+48	1975	Production	SOUND MIXING	SOUND	an0051341	Jaws	tt0073195	Robert L. Hoyt, Roger Heman, Earl Madery, John Carter	Robert L. Hoyt, Roger Heman, Earl Madery, John Carter	nm0398480,nm0375947,nm0531071,nm0141728	True
+48	1975	Production	SOUND MIXING	SOUND	an0051345	The Wind and the Lion	tt0073906	Harry W. Tetrick, Aaron Rochin, William McCaughey, Roy Charman	Harry W. Tetrick, Aaron Rochin, William McCaughey, Roy Charman	nm0856555,nm0734099,nm0565477,nm0153335
 48	1975	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0051317	Amarcord	tt0071129	Federico Fellini, Tonino Guerra	Federico Fellini, Tonino Guerra	nm0000019,nm0346096
 48	1975	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0051318	And Now My Love	tt0072307	Claude Lelouch, Pierre Uytterhoeven	Claude Lelouch, Pierre Uytterhoeven	nm0500988,nm0882683
 48	1975	Writing	WRITING (Original Screenplay)	WRITING (Original Screenplay)	an0051316	Dog Day Afternoon	tt0072890	Frank Pierson	Frank Pierson	nm0682757	True
@@ -5782,11 +5782,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 49	1976	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0054613	The Morning Spider	tt0074919	Julian Chagrin and Claude Chagrin, Producers	Julian Chagrin, Claude Chagrin	nm0149615,nm0149613
 49	1976	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0054614	Nightlife	tt0074966	Claire Wilbur and Robin Lehman, Producers	Claire Wilbur, Robin Lehman	nm0928106,nm0499651
 49	1976	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0054615	Number One	tt0074986	Dyan Cannon and Vince Cannon, Producers	Dyan Cannon, Vince Cannon	nm0001007,nm0134278
-49	1976	Production	SOUND	SOUND	an0054585	All the President's Men	tt0074119	Arthur Piantadosi, Les Fresholtz, Dick Alexander, Jim Webb	Arthur Piantadosi, Les Fresholtz, Dick Alexander, Jim Webb	nm0681250,nm0294370,nm1219804,nm0916137	True
-49	1976	Production	SOUND	SOUND	an0054586	King Kong	tt0074751	Harry Warren Tetrick, William McCaughey, Aaron Rochin, Jack Solomon	Harry Warren Tetrick, William McCaughey, Aaron Rochin, Jack Solomon	nm0856555,nm0565477,nm0734099,nm0813349
-49	1976	Production	SOUND	SOUND	an0054587	Rocky	tt0075148	Harry Warren Tetrick, William McCaughey, Lyle Burbridge, Bud Alper	Harry Warren Tetrick, William McCaughey, Lyle Burbridge, Bud Alper	nm0856555,nm0565477,nm0120769,nm0022356
-49	1976	Production	SOUND	SOUND	an0054588	Silver Streak	tt0075223	Donald Mitchell, Douglas Williams, Richard Tyler, Hal Etherington	Donald Mitchell, Douglas Williams, Richard Tyler, Hal Etherington	nm0593290,nm0930491,nm0878889,nm0262065
-49	1976	Production	SOUND	SOUND	an0054589	A Star Is Born	tt0075265	Robert Knudson, Dan Wallin, Robert Glass, Tom Overton	Robert Knudson, Dan Wallin, Robert Glass, Tom Overton	nm0461702,nm0909163,nm0321915,nm0653966
+49	1976	Production	SOUND MIXING	SOUND	an0054585	All the President's Men	tt0074119	Arthur Piantadosi, Les Fresholtz, Dick Alexander, Jim Webb	Arthur Piantadosi, Les Fresholtz, Dick Alexander, Jim Webb	nm0681250,nm0294370,nm1219804,nm0916137	True
+49	1976	Production	SOUND MIXING	SOUND	an0054586	King Kong	tt0074751	Harry Warren Tetrick, William McCaughey, Aaron Rochin, Jack Solomon	Harry Warren Tetrick, William McCaughey, Aaron Rochin, Jack Solomon	nm0856555,nm0565477,nm0734099,nm0813349
+49	1976	Production	SOUND MIXING	SOUND	an0054587	Rocky	tt0075148	Harry Warren Tetrick, William McCaughey, Lyle Burbridge, Bud Alper	Harry Warren Tetrick, William McCaughey, Lyle Burbridge, Bud Alper	nm0856555,nm0565477,nm0120769,nm0022356
+49	1976	Production	SOUND MIXING	SOUND	an0054588	Silver Streak	tt0075223	Donald Mitchell, Douglas Williams, Richard Tyler, Hal Etherington	Donald Mitchell, Douglas Williams, Richard Tyler, Hal Etherington	nm0593290,nm0930491,nm0878889,nm0262065
+49	1976	Production	SOUND MIXING	SOUND	an0054589	A Star Is Born	tt0075265	Robert Knudson, Dan Wallin, Robert Glass, Tom Overton	Robert Knudson, Dan Wallin, Robert Glass, Tom Overton	nm0461702,nm0909163,nm0321915,nm0653966
 49	1976	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0054565	All the President's Men	tt0074119	William Goldman	William Goldman	nm0001279	True
 49	1976	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0054566	Bound for Glory	tt0074235	Robert Getchell	Robert Getchell	nm0315205
 49	1976	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0054567	Fellini's Casanova	tt0074291	Federico Fellini, Bernardino Zapponi	Federico Fellini, Bernardino Zapponi	nm0000019,nm0953301
@@ -5894,11 +5894,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 50	1977	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051078	I'll Find a Way	tt0076173	Beverly Shaffer and Yuki Yoshida, Producers	Beverly Shaffer, Yuki Yoshida	nm0787291,nm0948952	True
 50	1977	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051081	Notes on the Popular Arts	tt0076467	Saul Bass, Producer	Saul Bass	nm0000866
 50	1977	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051082	Spaceborne	tt0076742	Philip Dauber, Producer	Philip Dauber	nm0202229
-50	1977	Production	SOUND	SOUND	an0051050	Close Encounters of the Third Kind	tt0075860	Robert Knudson, Robert J. Glass, Don MacDougall, Gene S. Cantamessa	Robert Knudson, Robert J. Glass, Don MacDougall, Gene S. Cantamessa	nm0461702,nm0321915,nm0532013,nm0134481
-50	1977	Production	SOUND	SOUND	an0051051	The Deep	tt0075925	Walter Goss, Dick Alexander, Tom Beckert, Robin Gregory	Walter Goss, Dick Alexander, Tom Beckert, Robin Gregory	nm0331586,nm1219804,nm0065657,nm0339932
-50	1977	Production	SOUND	SOUND	an0051052	Sorcerer	tt0076740	Robert Knudson, Robert J. Glass, Richard Tyler, Jean-Louis Ducarme	Robert Knudson, Robert J. Glass, Richard Tyler, Jean-Louis Ducarme	nm0461702,nm0321915,nm0878889,nm0239707
-50	1977	Production	SOUND	SOUND	an0051049	Star Wars	tt0076759	Don MacDougall, Ray West, Bob Minkler, Derek Ball	Don MacDougall, Ray West, Bob Minkler, Derek Ball	nm0532013,nm0922079,nm0591440,nm0050362	True
-50	1977	Production	SOUND	SOUND	an0051053	The Turning Point	tt0076843	Theodore Soderberg, Paul Wells, Douglas O. Williams, Jerry Jost	Theodore Soderberg, Paul Wells, Douglas O. Williams, Jerry Jost	nm0812029,nm0920372,nm0930491,nm0422281
+50	1977	Production	SOUND MIXING	SOUND	an0051050	Close Encounters of the Third Kind	tt0075860	Robert Knudson, Robert J. Glass, Don MacDougall, Gene S. Cantamessa	Robert Knudson, Robert J. Glass, Don MacDougall, Gene S. Cantamessa	nm0461702,nm0321915,nm0532013,nm0134481
+50	1977	Production	SOUND MIXING	SOUND	an0051051	The Deep	tt0075925	Walter Goss, Dick Alexander, Tom Beckert, Robin Gregory	Walter Goss, Dick Alexander, Tom Beckert, Robin Gregory	nm0331586,nm1219804,nm0065657,nm0339932
+50	1977	Production	SOUND MIXING	SOUND	an0051052	Sorcerer	tt0076740	Robert Knudson, Robert J. Glass, Richard Tyler, Jean-Louis Ducarme	Robert Knudson, Robert J. Glass, Richard Tyler, Jean-Louis Ducarme	nm0461702,nm0321915,nm0878889,nm0239707
+50	1977	Production	SOUND MIXING	SOUND	an0051049	Star Wars	tt0076759	Don MacDougall, Ray West, Bob Minkler, Derek Ball	Don MacDougall, Ray West, Bob Minkler, Derek Ball	nm0532013,nm0922079,nm0591440,nm0050362	True
+50	1977	Production	SOUND MIXING	SOUND	an0051053	The Turning Point	tt0076843	Theodore Soderberg, Paul Wells, Douglas O. Williams, Jerry Jost	Theodore Soderberg, Paul Wells, Douglas O. Williams, Jerry Jost	nm0812029,nm0920372,nm0930491,nm0422281
 50	1977	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0051060	Close Encounters of the Third Kind	tt0075860	Roy Arbogast, Douglas Trumbull, Matthew Yuricich, Gregory Jein, Richard Yuricich	Roy Arbogast, Douglas Trumbull, Matthew Yuricich, Gregory Jein, Richard Yuricich	nm0033405,nm0874320,nm0951046,nm0420478,nm0951047
 50	1977	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0051059	Star Wars	tt0076759	John Stears, John Dykstra, Richard Edlund, Grant McCune, Robert Blalack	John Stears, John Dykstra, Richard Edlund, Grant McCune, Robert Blalack	nm0824210,nm0004375,nm0249430,nm0567263,nm0086879	True
 50	1977	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay--based on material from another medium)	an0051030	Equus	tt0075995	Peter Shaffer	Peter Shaffer	nm0787323
@@ -6016,11 +6016,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 51	1978	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050202	Mandy's Grandmother	tt0077901	Andrew Sugerman, Producer	Andrew Sugerman	nm0837449
 51	1978	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050203	Strange Fruit	tt0078329	Seth Pinsker, Producer	Seth Pinsker	nm0684525
 51	1978	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050200	Teenage Father	tt0078372	Taylor Hackford, Producer	Taylor Hackford	nm0000431	True
-51	1978	Production	SOUND	SOUND	an0050175	The Buddy Holly Story	tt0077280	Tex Rudloff, Joel Fein, Curly Thirlwell, Willie Burton	Tex Rudloff, Joel Fein, Curly Thirlwell, Willie Burton	nm0748839,nm0270651,nm0858218,nm0123770
-51	1978	Production	SOUND	SOUND	an0050176	Days of Heaven	tt0077405	John K. Wilkinson, Robert W. Glass, Jr., John T. Reitz, Barry Thomas	John K. Wilkinson, Robert W. Glass Jr., John T. Reitz, Barry Thomas	nm0929414,nm0321903,nm0718676,nm0858508
-51	1978	Production	SOUND	SOUND	an0050174	The Deer Hunter	tt0077416	Richard Portman, William McCaughey, Aaron Rochin, Darin Knight	Richard Portman, William McCaughey, Aaron Rochin, Darin Knight	nm0692446,nm0565477,nm0734099,nm0460828	True
-51	1978	Production	SOUND	SOUND	an0050177	Hooper	tt0077696	Robert Knudson, Robert J. Glass, Don MacDougall, Jack Solomon	Robert Knudson, Robert J. Glass, Don MacDougall, Jack Solomon	nm0461702,nm0321915,nm0532013,nm0813349
-51	1978	Production	SOUND	SOUND	an0050178	Superman	tt0078346	Gordon K. McCallum, Graham Hartstone, Nicolas Le Messurier, Roy Charman	Gordon K. McCallum, Graham Hartstone, Nicolas Le Messurier, Roy Charman	nm0564730,nm0367242,nm0494449,nm0153335
+51	1978	Production	SOUND MIXING	SOUND	an0050175	The Buddy Holly Story	tt0077280	Tex Rudloff, Joel Fein, Curly Thirlwell, Willie Burton	Tex Rudloff, Joel Fein, Curly Thirlwell, Willie Burton	nm0748839,nm0270651,nm0858218,nm0123770
+51	1978	Production	SOUND MIXING	SOUND	an0050176	Days of Heaven	tt0077405	John K. Wilkinson, Robert W. Glass, Jr., John T. Reitz, Barry Thomas	John K. Wilkinson, Robert W. Glass Jr., John T. Reitz, Barry Thomas	nm0929414,nm0321903,nm0718676,nm0858508
+51	1978	Production	SOUND MIXING	SOUND	an0050174	The Deer Hunter	tt0077416	Richard Portman, William McCaughey, Aaron Rochin, Darin Knight	Richard Portman, William McCaughey, Aaron Rochin, Darin Knight	nm0692446,nm0565477,nm0734099,nm0460828	True
+51	1978	Production	SOUND MIXING	SOUND	an0050177	Hooper	tt0077696	Robert Knudson, Robert J. Glass, Don MacDougall, Jack Solomon	Robert Knudson, Robert J. Glass, Don MacDougall, Jack Solomon	nm0461702,nm0321915,nm0532013,nm0813349
+51	1978	Production	SOUND MIXING	SOUND	an0050178	Superman	tt0078346	Gordon K. McCallum, Graham Hartstone, Nicolas Le Messurier, Roy Charman	Gordon K. McCallum, Graham Hartstone, Nicolas Le Messurier, Roy Charman	nm0564730,nm0367242,nm0494449,nm0153335
 51	1978	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0050155	Bloodbrothers	tt0078878	Walter Newman	Walter Newman	nm0628305
 51	1978	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0050156	California Suite	tt0077289	Neil Simon	Neil Simon	nm0800319
 51	1978	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0050157	Heaven Can Wait	tt0077663	Elaine May, Warren Beatty	Elaine May, Warren Beatty	nm0561938,nm0000886
@@ -6136,11 +6136,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 52	1979	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0057156	Oh Brother, My Brother	tt0079656	Carol Lowell and Ross Lowell, Producers	Carol Lowell, Ross Lowell	nm0523082,nm0523112
 52	1979	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0057157	The Solar Film	tt0083104	Saul Bass and Michael Britton, Producers	Saul Bass, Michael Britton	nm0000866,nm0110212
 52	1979	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0057158	Solly's Diner	tt0079923	Harry Mathias, Jay Zukerman and Larry Hankin, Producers	Harry Mathias, Jay Zukerman, Larry Hankin	nm0558760,nm0958426,nm0359969
-52	1979	Production	SOUND	SOUND	an0057123	Apocalypse Now	tt0078788	Walter Murch, Mark Berger, Richard Beggs, Nat Boxer	Walter Murch, Mark Berger, Richard Beggs, Nat Boxer	nm0004555,nm0074281,nm0066740,nm0101537	True
-52	1979	Production	SOUND	SOUND	an0057124	The Electric Horseman	tt0079100	Arthur Piantadosi, Les Fresholtz, Michael Minkler, Al Overton	Arthur Piantadosi, Les Fresholtz, Michael Minkler, Al Overton	nm0681250,nm0294370,nm0591444,nm0653929
-52	1979	Production	SOUND	SOUND	an0057125	Meteor	tt0079550	William McCaughey, Aaron Rochin, Michael J. Kohut, Jack Solomon	William McCaughey, Aaron Rochin, Michael J. Kohut, Jack Solomon	nm0565477,nm0734099,nm0463489,nm0813349
-52	1979	Production	SOUND	SOUND	an0057126	1941	tt0078723	Robert Knudson, Robert J. Glass, Don MacDougall, Gene S. Cantamessa	Robert Knudson, Robert J. Glass, Don MacDougall, Gene S. Cantamessa	nm0461702,nm0321915,nm0532013,nm0134481
-52	1979	Production	SOUND	SOUND	an0057127	The Rose	tt0079826	Theodore Soderberg, Douglas Williams, Paul Wells, Jim Webb	Theodore Soderberg, Douglas Williams, Paul Wells, Jim Webb	nm0812029,nm0930491,nm0920372,nm0916137
+52	1979	Production	SOUND MIXING	SOUND	an0057123	Apocalypse Now	tt0078788	Walter Murch, Mark Berger, Richard Beggs, Nat Boxer	Walter Murch, Mark Berger, Richard Beggs, Nat Boxer	nm0004555,nm0074281,nm0066740,nm0101537	True
+52	1979	Production	SOUND MIXING	SOUND	an0057124	The Electric Horseman	tt0079100	Arthur Piantadosi, Les Fresholtz, Michael Minkler, Al Overton	Arthur Piantadosi, Les Fresholtz, Michael Minkler, Al Overton	nm0681250,nm0294370,nm0591444,nm0653929
+52	1979	Production	SOUND MIXING	SOUND	an0057125	Meteor	tt0079550	William McCaughey, Aaron Rochin, Michael J. Kohut, Jack Solomon	William McCaughey, Aaron Rochin, Michael J. Kohut, Jack Solomon	nm0565477,nm0734099,nm0463489,nm0813349
+52	1979	Production	SOUND MIXING	SOUND	an0057126	1941	tt0078723	Robert Knudson, Robert J. Glass, Don MacDougall, Gene S. Cantamessa	Robert Knudson, Robert J. Glass, Don MacDougall, Gene S. Cantamessa	nm0461702,nm0321915,nm0532013,nm0134481
+52	1979	Production	SOUND MIXING	SOUND	an0057127	The Rose	tt0079826	Theodore Soderberg, Douglas Williams, Paul Wells, Jim Webb	Theodore Soderberg, Douglas Williams, Paul Wells, Jim Webb	nm0812029,nm0930491,nm0920372,nm0916137
 52	1979	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0057133	Alien	tt0078748	H.R. Giger, Carlo Rambaldi, Brian Johnson, Nick Allder, Denys Ayling	H.R. Giger, Carlo Rambaldi, Brian Johnson, Nick Allder, Denys Ayling	nm0317592,nm0708058,nm0424644,nm0020158,nm0043861	True
 52	1979	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0057134	The Black Hole	tt0078869	Peter Ellenshaw, Art Cruickshank, Eustace Lycett, Danny Lee, Harrison Ellenshaw, Joe Hale	Peter Ellenshaw, Art Cruickshank, Eustace Lycett, Danny Lee, Harrison Ellenshaw, Joe Hale	nm0254002,nm0189973,nm0527941,nm0497098,nm0254001,nm0354940
 52	1979	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0057135	Moonraker	tt0079574	Derek Meddings, Paul Wilson, John Evans	Derek Meddings, Paul Wilson, John Evans	nm0575439,nm0933946,nm0262906
@@ -6252,14 +6252,14 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 53	1980	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0054849	All Nothing	tt0080351	Frédéric Back, Producer	Frédéric Back	nm0045610
 53	1980	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0054848	The Fly	tt0081040	Ferenc Rofusz, Producer	Ferenc Rofusz	nm0736537	True
 53	1980	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0054850	History of the World in Three Minutes Flat	tt0080879	Michael Mills, Producer	Michael Mills	nm3382237
-53	1980	Title	SHORT FILM (Dramatic Live Action)	SHORT FILM (Dramatic Live Action)	an0054851	The Dollar Bottom	tt0080643	Lloyd Phillips, Producer	Lloyd Phillips	nm0680595	True
-53	1980	Title	SHORT FILM (Dramatic Live Action)	SHORT FILM (Dramatic Live Action)	an0054852	Fall Line	tt0080713	Bob Carmichael and Greg Lowe, Producers	Bob Carmichael, Greg Lowe	nm0138456,nm7020894
-53	1980	Title	SHORT FILM (Dramatic Live Action)	SHORT FILM (Dramatic Live Action)	an0054853	A Jury of Her Peers	tt0080974	Sally Heckel, Producer	Sally Heckel	nm0373021
-53	1980	Production	SOUND	SOUND	an0054829	Altered States	tt0080360	Arthur Piantadosi, Les Fresholtz, Michael Minkler, Willie D. Burton	Arthur Piantadosi, Les Fresholtz, Michael Minkler, Willie D. Burton	nm0681250,nm0294370,nm0591444,nm0123770
-53	1980	Production	SOUND	SOUND	an0054830	Coal Miner's Daughter	tt0080549	Richard Portman, Roger Heman, Jim Alexander	Richard Portman, Roger Heman, Jim Alexander	nm0692446,nm0375947,nm0018482
-53	1980	Production	SOUND	SOUND	an0054828	The Empire Strikes Back	tt0080684	Bill Varney, Steve Maslow, Gregg Landaker, Peter Sutton	Bill Varney, Steve Maslow, Gregg Landaker, Peter Sutton	nm0890106,nm0556541,nm0484414,nm0840379	True
-53	1980	Production	SOUND	SOUND	an0054831	Fame	tt0080716	Michael J. Kohut, Aaron Rochin, Jay M. Harding, Chris Newman	Michael J. Kohut, Aaron Rochin, Jay M. Harding, Chris Newman	nm0463489,nm0734099,nm0362326,nm0628039
-53	1980	Production	SOUND	SOUND	an0054832	Raging Bull	tt0081398	Donald O. Mitchell, Bill Nicholson, David J. Kimball, Les Lazarowitz	Donald O. Mitchell, Bill Nicholson, David J. Kimball, Les Lazarowitz	nm0593290,nm0629779,nm0453795,nm0493796
+53	1980	Title	SHORT FILM (Live Action)	SHORT FILM (Dramatic Live Action)	an0054851	The Dollar Bottom	tt0080643	Lloyd Phillips, Producer	Lloyd Phillips	nm0680595	True
+53	1980	Title	SHORT FILM (Live Action)	SHORT FILM (Dramatic Live Action)	an0054852	Fall Line	tt0080713	Bob Carmichael and Greg Lowe, Producers	Bob Carmichael, Greg Lowe	nm0138456,nm7020894
+53	1980	Title	SHORT FILM (Live Action)	SHORT FILM (Dramatic Live Action)	an0054853	A Jury of Her Peers	tt0080974	Sally Heckel, Producer	Sally Heckel	nm0373021
+53	1980	Production	SOUND MIXING	SOUND	an0054829	Altered States	tt0080360	Arthur Piantadosi, Les Fresholtz, Michael Minkler, Willie D. Burton	Arthur Piantadosi, Les Fresholtz, Michael Minkler, Willie D. Burton	nm0681250,nm0294370,nm0591444,nm0123770
+53	1980	Production	SOUND MIXING	SOUND	an0054830	Coal Miner's Daughter	tt0080549	Richard Portman, Roger Heman, Jim Alexander	Richard Portman, Roger Heman, Jim Alexander	nm0692446,nm0375947,nm0018482
+53	1980	Production	SOUND MIXING	SOUND	an0054828	The Empire Strikes Back	tt0080684	Bill Varney, Steve Maslow, Gregg Landaker, Peter Sutton	Bill Varney, Steve Maslow, Gregg Landaker, Peter Sutton	nm0890106,nm0556541,nm0484414,nm0840379	True
+53	1980	Production	SOUND MIXING	SOUND	an0054831	Fame	tt0080716	Michael J. Kohut, Aaron Rochin, Jay M. Harding, Chris Newman	Michael J. Kohut, Aaron Rochin, Jay M. Harding, Chris Newman	nm0463489,nm0734099,nm0362326,nm0628039
+53	1980	Production	SOUND MIXING	SOUND	an0054832	Raging Bull	tt0081398	Donald O. Mitchell, Bill Nicholson, David J. Kimball, Les Lazarowitz	Donald O. Mitchell, Bill Nicholson, David J. Kimball, Les Lazarowitz	nm0593290,nm0629779,nm0453795,nm0493796
 53	1980	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0054809	Breaker Morant	tt0080310	Jonathan Hardy, David Stevens, Bruce Beresford	Jonathan Hardy, David Stevens, Bruce Beresford	nm0362682,nm0828350,nm0000915
 53	1980	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0054810	Coal Miner's Daughter	tt0080549	Tom Rickman	Tom Rickman	nm0725564
 53	1980	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0054811	The Elephant Man	tt0080678	Christopher DeVore, Eric Bergren, David Lynch	Christopher DeVore, Eric Bergren, David Lynch	nm0212246,nm0075015,nm0000186
@@ -6369,11 +6369,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 54	1981	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049804	Couples and Robbers	tt0082207	Christine Oestreicher, Producer	Christine Oestreicher	nm0644325
 54	1981	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049805	First Winter	tt0082383	John N. Smith, Producer	John N. Smith	nm0808807
 54	1981	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049803	Violet	tt0083293	Paul Kemp and Shelley Levinson, Producers	Paul Kemp, Shelley Levinson	nm0447351,nm0506099	True
-54	1981	Production	SOUND	SOUND	an0049777	On Golden Pond	tt0082846	Richard Portman, David Ronne	Richard Portman, David Ronne	nm0692446,nm0740122
-54	1981	Production	SOUND	SOUND	an0049778	Outland	tt0082869	John K. Wilkinson, Robert W. Glass, Jr., Robert M. Thirlwell, Robin Gregory	John K. Wilkinson, Robert W. Glass Jr., Robert M. Thirlwell, Robin Gregory	nm0929414,nm0321903,nm0858222,nm0339932
-54	1981	Production	SOUND	SOUND	an0049779	Pennies from Heaven	tt0082894	Michael J. Kohut, Jay M. Harding, Richard Tyler, Al Overton	Michael J. Kohut, Jay M. Harding, Richard Tyler, Al Overton	nm0463489,nm0362326,nm0878889,nm0653929
-54	1981	Production	SOUND	SOUND	an0049776	Raiders of the Lost Ark	tt0082971	Bill Varney, Steve Maslow, Gregg Landaker, Roy Charman	Bill Varney, Steve Maslow, Gregg Landaker, Roy Charman	nm0890106,nm0556541,nm0484414,nm0153335	True
-54	1981	Production	SOUND	SOUND	an0049780	Reds	tt0082979	Dick Vorisek, Tom Fleischman, Simon Kaye	Dick Vorisek, Tom Fleischman, Simon Kaye	nm0903459,nm0281530,nm0443393
+54	1981	Production	SOUND MIXING	SOUND	an0049777	On Golden Pond	tt0082846	Richard Portman, David Ronne	Richard Portman, David Ronne	nm0692446,nm0740122
+54	1981	Production	SOUND MIXING	SOUND	an0049778	Outland	tt0082869	John K. Wilkinson, Robert W. Glass, Jr., Robert M. Thirlwell, Robin Gregory	John K. Wilkinson, Robert W. Glass Jr., Robert M. Thirlwell, Robin Gregory	nm0929414,nm0321903,nm0858222,nm0339932
+54	1981	Production	SOUND MIXING	SOUND	an0049779	Pennies from Heaven	tt0082894	Michael J. Kohut, Jay M. Harding, Richard Tyler, Al Overton	Michael J. Kohut, Jay M. Harding, Richard Tyler, Al Overton	nm0463489,nm0362326,nm0878889,nm0653929
+54	1981	Production	SOUND MIXING	SOUND	an0049776	Raiders of the Lost Ark	tt0082971	Bill Varney, Steve Maslow, Gregg Landaker, Roy Charman	Bill Varney, Steve Maslow, Gregg Landaker, Roy Charman	nm0890106,nm0556541,nm0484414,nm0153335	True
+54	1981	Production	SOUND MIXING	SOUND	an0049780	Reds	tt0082979	Dick Vorisek, Tom Fleischman, Simon Kaye	Dick Vorisek, Tom Fleischman, Simon Kaye	nm0903459,nm0281530,nm0443393
 54	1981	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0049787	Dragonslayer	tt0082288	Dennis Muren, Phil Tippett, Ken Ralston, Brian Johnson	Dennis Muren, Phil Tippett, Ken Ralston, Brian Johnson	nm0613830,nm0864138,nm0707822,nm0424644
 54	1981	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0049786	Raiders of the Lost Ark	tt0082971	Richard Edlund, Kit West, Bruce Nicholson, Joe Johnston	Richard Edlund, Kit West, Bruce Nicholson, Joe Johnston	nm0249430,nm0922187,nm0629785,nm0002653	True
 54	1981	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0049757	The French Lieutenant's Woman	tt0082416	Harold Pinter	Harold Pinter	nm0056217
@@ -6493,11 +6493,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 55	1982	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052050	The Silence	tt0084683	Michael Toshiyuki Uno and Joseph Benson, Producers	Michael Toshiyuki Uno, Joseph Benson	nm0881306,nm0072544
 55	1982	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052051	Split Cherry Tree	tt0084713	Jan Saunders, Producer	Jan Saunders	nm0766834
 55	1982	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052052	Sredni Vashtar	tt0084722	Andrew Birkin, Producer	Andrew Birkin	nm0001949
-55	1982	Production	SOUND	SOUND	an0052015	Das Boot	tt0082096	Milan Bor, Trevor Pyke, Mike Le-Mare	Milan Bor, Trevor Pyke, Mike Le-Mare	nm0095914,nm0701483,nm0494420
-55	1982	Production	SOUND	SOUND	an0052014	E.T. The Extra-Terrestrial	tt0083866	Robert Knudson, Robert Glass, Don Digirolamo, Gene Cantamessa	Robert Knudson, Robert Glass, Don Digirolamo, Gene Cantamessa	nm0461702,nm0321915,nm0226564,nm0134481	True
-55	1982	Production	SOUND	SOUND	an0052016	Gandhi	tt0083987	Gerry Humphreys, Robin O'Donoghue, Jonathan Bates, Simon Kaye	Gerry Humphreys, Robin O'Donoghue, Jonathan Bates, Simon Kaye	nm0006836,nm0640877,nm0060952,nm0443393
-55	1982	Production	SOUND	SOUND	an0052017	Tootsie	tt0084805	Arthur Piantadosi, Les Fresholtz, Dick Alexander, Les Lazarowitz	Arthur Piantadosi, Les Fresholtz, Dick Alexander, Les Lazarowitz	nm0681250,nm0294370,nm1219804,nm0493796
-55	1982	Production	SOUND	SOUND	an0052018	Tron	tt0084827	Michael Minkler, Bob Minkler, Lee Minkler, Jim La Rue	Michael Minkler, Bob Minkler, Lee Minkler, Jim La Rue	nm0591444,nm0591440,nm0591443,nm0489341
+55	1982	Production	SOUND MIXING	SOUND	an0052015	Das Boot	tt0082096	Milan Bor, Trevor Pyke, Mike Le-Mare	Milan Bor, Trevor Pyke, Mike Le-Mare	nm0095914,nm0701483,nm0494420
+55	1982	Production	SOUND MIXING	SOUND	an0052014	E.T. The Extra-Terrestrial	tt0083866	Robert Knudson, Robert Glass, Don Digirolamo, Gene Cantamessa	Robert Knudson, Robert Glass, Don Digirolamo, Gene Cantamessa	nm0461702,nm0321915,nm0226564,nm0134481	True
+55	1982	Production	SOUND MIXING	SOUND	an0052016	Gandhi	tt0083987	Gerry Humphreys, Robin O'Donoghue, Jonathan Bates, Simon Kaye	Gerry Humphreys, Robin O'Donoghue, Jonathan Bates, Simon Kaye	nm0006836,nm0640877,nm0060952,nm0443393
+55	1982	Production	SOUND MIXING	SOUND	an0052017	Tootsie	tt0084805	Arthur Piantadosi, Les Fresholtz, Dick Alexander, Les Lazarowitz	Arthur Piantadosi, Les Fresholtz, Dick Alexander, Les Lazarowitz	nm0681250,nm0294370,nm1219804,nm0493796
+55	1982	Production	SOUND MIXING	SOUND	an0052018	Tron	tt0084827	Michael Minkler, Bob Minkler, Lee Minkler, Jim La Rue	Michael Minkler, Bob Minkler, Lee Minkler, Jim La Rue	nm0591444,nm0591440,nm0591443,nm0489341
 55	1982	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0052028	Das Boot	tt0082096	Mike Le-Mare	Mike Le-Mare	nm0494420
 55	1982	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0052027	E.T. The Extra-Terrestrial	tt0083866	Charles L. Campbell, Ben Burtt	Charles L. Campbell, Ben Burtt	nm0132287,nm0123785	True
 55	1982	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0052029	Poltergeist	tt0084516	Stephen Hunter Flick, Richard L. Anderson	Stephen Hunter Flick, Richard L. Anderson	nm0282276,nm0027328
@@ -6612,11 +6612,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 56	1983	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052167	Boys and Girls	tt0083688	Janice L. Platt, Producer	Janice L. Platt	nm0686864	True
 56	1983	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052168	Goodie-Two-Shoes	tt0085613	Ian Emes, Producer	Ian Emes	nm0256357
 56	1983	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052169	Overnight Sensation	tt0086067	Jon N. Bloom, Producer	Jon N. Bloom	nm0089186
-56	1983	Production	SOUND	SOUND	an0052140	Never Cry Wolf	tt0086005	Alan R. Splet, Todd Boekelheide, Randy Thom, David Parker	Alan R. Splet, Todd Boekelheide, Randy Thom, David Parker	nm0819263,nm0091250,nm0858378,nm0662188
-56	1983	Production	SOUND	SOUND	an0052141	Return of the Jedi	tt0086190	Ben Burtt, Gary Summers, Randy Thom, Tony Dawe	Ben Burtt, Gary Summers, Randy Thom, Tony Dawe	nm0123785,nm0838707,nm0858378,nm0003360
-56	1983	Production	SOUND	SOUND	an0052139	The Right Stuff	tt0086197	Mark Berger, Tom Scott, Randy Thom, David MacMillan	Mark Berger, Tom Scott, Randy Thom, David MacMillan	nm0074281,nm0779845,nm0858378,nm0533997	True
-56	1983	Production	SOUND	SOUND	an0052142	Terms of Endearment	tt0086425	Donald O. Mitchell, Rick Kline, Kevin O'Connell, Jim Alexander	Donald O. Mitchell, Rick Kline, Kevin O'Connell, Jim Alexander	nm0593290,nm0459662,nm0640114,nm0018482
-56	1983	Production	SOUND	SOUND	an0052143	WarGames	tt0086567	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Willie D. Burton	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Willie D. Burton	nm0463489,nm0216467,nm0734099,nm0123770
+56	1983	Production	SOUND MIXING	SOUND	an0052140	Never Cry Wolf	tt0086005	Alan R. Splet, Todd Boekelheide, Randy Thom, David Parker	Alan R. Splet, Todd Boekelheide, Randy Thom, David Parker	nm0819263,nm0091250,nm0858378,nm0662188
+56	1983	Production	SOUND MIXING	SOUND	an0052141	Return of the Jedi	tt0086190	Ben Burtt, Gary Summers, Randy Thom, Tony Dawe	Ben Burtt, Gary Summers, Randy Thom, Tony Dawe	nm0123785,nm0838707,nm0858378,nm0003360
+56	1983	Production	SOUND MIXING	SOUND	an0052139	The Right Stuff	tt0086197	Mark Berger, Tom Scott, Randy Thom, David MacMillan	Mark Berger, Tom Scott, Randy Thom, David MacMillan	nm0074281,nm0779845,nm0858378,nm0533997	True
+56	1983	Production	SOUND MIXING	SOUND	an0052142	Terms of Endearment	tt0086425	Donald O. Mitchell, Rick Kline, Kevin O'Connell, Jim Alexander	Donald O. Mitchell, Rick Kline, Kevin O'Connell, Jim Alexander	nm0593290,nm0459662,nm0640114,nm0018482
+56	1983	Production	SOUND MIXING	SOUND	an0052143	WarGames	tt0086567	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Willie D. Burton	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Willie D. Burton	nm0463489,nm0216467,nm0734099,nm0123770
 56	1983	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0052150	Return of the Jedi	tt0086190	Ben Burtt	Ben Burtt	nm0123785
 56	1983	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0052149	The Right Stuff	tt0086197	Jay Boekelheide	Jay Boekelheide	nm0091249	True
 56	1983	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0052120	Betrayal	tt0085234	Harold Pinter	Harold Pinter	nm0056217
@@ -6730,11 +6730,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 57	1984	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052897	The Painted Door	tt0087871	Michael MacMillan and Janice L. Platt, Producers	Michael MacMillan, Janice L. Platt	nm0534016,nm0686864
 57	1984	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052898	Tales of Meeting and Parting	tt0088223	Sharon Oreck and Lesli Linka Glatter, Producers	Sharon Oreck, Lesli Linka Glatter	nm0649610,nm0322128
 57	1984	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052896	Up	tt0088332	Mike Hoover, Producer	Mike Hoover	nm0393914	True
-57	1984	Production	SOUND	SOUND	an0052864	Amadeus	tt0086879	Mark Berger, Tom Scott, Todd Boekelheide, Chris Newman	Mark Berger, Tom Scott, Todd Boekelheide, Chris Newman	nm0074281,nm0779845,nm0091250,nm0628039	True
-57	1984	Production	SOUND	SOUND	an0052865	Dune	tt0087182	Bill Varney, Steve Maslow, Kevin O'Connell, Nelson Stoll	Bill Varney, Steve Maslow, Kevin O'Connell, Nelson Stoll	nm0890106,nm0556541,nm0640114,nm0831523
-57	1984	Production	SOUND	SOUND	an0052866	A Passage to India	tt0087892	Graham V. Hartstone, Nicolas Le Messurier, Michael A. Carter, John Mitchell	Graham V. Hartstone, Nicolas Le Messurier, Michael A. Carter, John Mitchell	nm0367242,nm0494449,nm0141821,nm0593466
-57	1984	Production	SOUND	SOUND	an0052867	The River	tt0088007	Nick Alphin, Robert Thirlwell, Richard Portman, David Ronne	Nick Alphin, Robert Thirlwell, Richard Portman, David Ronne	nm0022441,nm0858222,nm0692446,nm0740122
-57	1984	Production	SOUND	SOUND	an0052868	2010	tt0086837	Michael J. Kohut, Aaron Rochin, Carlos De Larios, Gene S. Cantamessa	Michael J. Kohut, Aaron Rochin, Carlos De Larios, Gene S. Cantamessa	nm0463489,nm0734099,nm0216467,nm0134481
+57	1984	Production	SOUND MIXING	SOUND	an0052864	Amadeus	tt0086879	Mark Berger, Tom Scott, Todd Boekelheide, Chris Newman	Mark Berger, Tom Scott, Todd Boekelheide, Chris Newman	nm0074281,nm0779845,nm0091250,nm0628039	True
+57	1984	Production	SOUND MIXING	SOUND	an0052865	Dune	tt0087182	Bill Varney, Steve Maslow, Kevin O'Connell, Nelson Stoll	Bill Varney, Steve Maslow, Kevin O'Connell, Nelson Stoll	nm0890106,nm0556541,nm0640114,nm0831523
+57	1984	Production	SOUND MIXING	SOUND	an0052866	A Passage to India	tt0087892	Graham V. Hartstone, Nicolas Le Messurier, Michael A. Carter, John Mitchell	Graham V. Hartstone, Nicolas Le Messurier, Michael A. Carter, John Mitchell	nm0367242,nm0494449,nm0141821,nm0593466
+57	1984	Production	SOUND MIXING	SOUND	an0052867	The River	tt0088007	Nick Alphin, Robert Thirlwell, Richard Portman, David Ronne	Nick Alphin, Robert Thirlwell, Richard Portman, David Ronne	nm0022441,nm0858222,nm0692446,nm0740122
+57	1984	Production	SOUND MIXING	SOUND	an0052868	2010	tt0086837	Michael J. Kohut, Aaron Rochin, Carlos De Larios, Gene S. Cantamessa	Michael J. Kohut, Aaron Rochin, Carlos De Larios, Gene S. Cantamessa	nm0463489,nm0734099,nm0216467,nm0134481
 57	1984	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0052875	Ghostbusters	tt0087332	Richard Edlund, John Bruno, Mark Vargo, Chuck Gaspar	Richard Edlund, John Bruno, Mark Vargo, Chuck Gaspar	nm0249430,nm0116497,nm0889951,nm0309176
 57	1984	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0052874	Indiana Jones and the Temple of Doom	tt0087469	Dennis Muren, Michael McAlister, Lorne Peterson, George Gibbs	Dennis Muren, Michael McAlister, Lorne Peterson, George Gibbs	nm0613830,nm0563943,nm0677285,nm0316672	True
 57	1984	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0052876	2010	tt0086837	Richard Edlund, Neil Krepela, George Jenson, Mark Stetson	Richard Edlund, Neil Krepela, George Jenson, Mark Stetson	nm0249430,nm0470878,nm0421453,nm0828078
@@ -6847,11 +6847,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 58	1985	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0048092	Graffiti	tt0089225	Dianna Costello, Producer	Dianna Costello	nm0182535
 58	1985	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0048091	Molly's Pilgrim	tt0089612	Jeff Brown and Chris Pelzer, Producers	Jeff Brown, Chris Pelzer	nm0113819,nm0671410	True
 58	1985	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0048093	Rainbow War	tt0089878	Bob Rogers, Producer	Bob Rogers	nm0736748
-58	1985	Production	SOUND	SOUND	an0048060	Back to the Future	tt0088763	Bill Varney, B. Tennyson Sebastian II, Robert Thirlwell, William B. Kaplan	Bill Varney, B. Tennyson Sebastian II, Robert Thirlwell, William B. Kaplan	nm0890106,nm0780928,nm0858222,nm0438202
-58	1985	Production	SOUND	SOUND	an0048061	A Chorus Line	tt0088915	Donald O. Mitchell, Michael Minkler, Gerry Humphreys, Chris Newman	Donald O. Mitchell, Michael Minkler, Gerry Humphreys, Chris Newman	nm0593290,nm0591444,nm0006836,nm0628039
-58	1985	Production	SOUND	SOUND	an0048062	Ladyhawke	tt0089457	Les Fresholtz, Dick Alexander, Vern Poore, Bud Alper	Les Fresholtz, Dick Alexander, Vern Poore, Bud Alper	nm0294370,nm1219804,nm0691005,nm0022356
-58	1985	Production	SOUND	SOUND	an0048059	Out of Africa	tt0089755	Chris Jenkins, Gary Alexander, Larry Stensvold, Peter Handford	Chris Jenkins, Gary Alexander, Larry Stensvold, Peter Handford	nm0420804,nm0018428,nm0826703,nm0359542	True
-58	1985	Production	SOUND	SOUND	an0048063	Silverado	tt0090022	Donald O. Mitchell, Rick Kline, Kevin O'Connell, David Ronne	Donald O. Mitchell, Rick Kline, Kevin O'Connell, David Ronne	nm0593290,nm0459662,nm0640114,nm0740122
+58	1985	Production	SOUND MIXING	SOUND	an0048060	Back to the Future	tt0088763	Bill Varney, B. Tennyson Sebastian II, Robert Thirlwell, William B. Kaplan	Bill Varney, B. Tennyson Sebastian II, Robert Thirlwell, William B. Kaplan	nm0890106,nm0780928,nm0858222,nm0438202
+58	1985	Production	SOUND MIXING	SOUND	an0048061	A Chorus Line	tt0088915	Donald O. Mitchell, Michael Minkler, Gerry Humphreys, Chris Newman	Donald O. Mitchell, Michael Minkler, Gerry Humphreys, Chris Newman	nm0593290,nm0591444,nm0006836,nm0628039
+58	1985	Production	SOUND MIXING	SOUND	an0048062	Ladyhawke	tt0089457	Les Fresholtz, Dick Alexander, Vern Poore, Bud Alper	Les Fresholtz, Dick Alexander, Vern Poore, Bud Alper	nm0294370,nm1219804,nm0691005,nm0022356
+58	1985	Production	SOUND MIXING	SOUND	an0048059	Out of Africa	tt0089755	Chris Jenkins, Gary Alexander, Larry Stensvold, Peter Handford	Chris Jenkins, Gary Alexander, Larry Stensvold, Peter Handford	nm0420804,nm0018428,nm0826703,nm0359542	True
+58	1985	Production	SOUND MIXING	SOUND	an0048063	Silverado	tt0090022	Donald O. Mitchell, Rick Kline, Kevin O'Connell, David Ronne	Donald O. Mitchell, Rick Kline, Kevin O'Connell, David Ronne	nm0593290,nm0459662,nm0640114,nm0740122
 58	1985	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0048072	Back to the Future	tt0088763	Charles L. Campbell, Robert Rutledge	Charles L. Campbell, Robert Rutledge	nm0132287,nm0752091	True
 58	1985	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0048073	Ladyhawke	tt0089457	Bob Henderson, Alan Murray	Bob Henderson, Alan Murray	nm0376583,nm0614812
 58	1985	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0048074	Rambo: First Blood Part II	tt0089880	Frederick J. Brown	Frederick J. Brown	nm0113578
@@ -6963,11 +6963,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 59	1986	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049230	Exit	tt0091021	Stefano Reali and Pino Quartullo, Producers	Stefano Reali, Pino Quartullo	nm0714058,nm0702959
 59	1986	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049231	Love Struck	tt0091438	Fredda Weiss, Producer	Fredda Weiss	nm0918985
 59	1986	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049229	Precious Images	tt0091787	Chuck Workman, Producer	Chuck Workman	nm0941457	True
-59	1986	Production	SOUND	SOUND	an0049198	Aliens	tt0090605	Graham V. Hartstone, Nicolas Le Messurier, Michael A. Carter, Roy Charman	Graham V. Hartstone, Nicolas Le Messurier, Michael A. Carter, Roy Charman	nm0367242,nm0494449,nm0141821,nm0153335
-59	1986	Production	SOUND	SOUND	an0049199	Heartbreak Ridge	tt0091187	Les Fresholtz, Dick Alexander, Vern Poore, William Nelson	Les Fresholtz, Dick Alexander, Vern Poore, William Nelson	nm0294370,nm1219804,nm0691005,nm0625179
-59	1986	Production	SOUND	SOUND	an0049197	Platoon	tt0091763	John K. Wilkinson, Richard Rogers, Charles 'Bud' Grenzbach, Simon Kaye	John K. Wilkinson, Richard Rogers, Charles 'Bud' Grenzbach, Simon Kaye	nm0929414,nm0737147,nm0340311,nm0443393	True
-59	1986	Production	SOUND	SOUND	an0049200	Star Trek IV: The Voyage Home	tt0092007	Terry Porter, Dave Hudson, Mel Metcalfe, Gene S. Cantamessa	Terry Porter, Dave Hudson, Mel Metcalfe, Gene S. Cantamessa	nm0692310,nm0399812,nm0582467,nm0134481
-59	1986	Production	SOUND	SOUND	an0049201	Top Gun	tt0092099	Donald O. Mitchell, Kevin O'Connell, Rick Kline, William B. Kaplan	Donald O. Mitchell, Kevin O'Connell, Rick Kline, William B. Kaplan	nm0593290,nm0640114,nm0459662,nm0438202
+59	1986	Production	SOUND MIXING	SOUND	an0049198	Aliens	tt0090605	Graham V. Hartstone, Nicolas Le Messurier, Michael A. Carter, Roy Charman	Graham V. Hartstone, Nicolas Le Messurier, Michael A. Carter, Roy Charman	nm0367242,nm0494449,nm0141821,nm0153335
+59	1986	Production	SOUND MIXING	SOUND	an0049199	Heartbreak Ridge	tt0091187	Les Fresholtz, Dick Alexander, Vern Poore, William Nelson	Les Fresholtz, Dick Alexander, Vern Poore, William Nelson	nm0294370,nm1219804,nm0691005,nm0625179
+59	1986	Production	SOUND MIXING	SOUND	an0049197	Platoon	tt0091763	John K. Wilkinson, Richard Rogers, Charles 'Bud' Grenzbach, Simon Kaye	John K. Wilkinson, Richard Rogers, Charles 'Bud' Grenzbach, Simon Kaye	nm0929414,nm0737147,nm0340311,nm0443393	True
+59	1986	Production	SOUND MIXING	SOUND	an0049200	Star Trek IV: The Voyage Home	tt0092007	Terry Porter, Dave Hudson, Mel Metcalfe, Gene S. Cantamessa	Terry Porter, Dave Hudson, Mel Metcalfe, Gene S. Cantamessa	nm0692310,nm0399812,nm0582467,nm0134481
+59	1986	Production	SOUND MIXING	SOUND	an0049201	Top Gun	tt0092099	Donald O. Mitchell, Kevin O'Connell, Rick Kline, William B. Kaplan	Donald O. Mitchell, Kevin O'Connell, Rick Kline, William B. Kaplan	nm0593290,nm0640114,nm0459662,nm0438202
 59	1986	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049207	Aliens	tt0090605	Don Sharpe	Don Sharpe	nm0789216	True
 59	1986	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049208	Star Trek IV: The Voyage Home	tt0092007	Mark Mangini	Mark Mangini	nm0005625
 59	1986	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049209	Top Gun	tt0092099	Cecelia Hall, George Watters II	Cecelia Hall, George Watters II	nm0355398,nm0915036
@@ -7085,11 +7085,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 60	1987	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050977	Making Waves	tt0093478	Ann Wingate, Producer	Ann Wingate	nm0934990
 60	1987	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050976	Ray's Male Heterosexual Dance Hall	tt0093826	Jonathan Sanger and Jana Sue Memel, Producers	Jonathan Sanger, Jana Sue Memel	nm0762674,nm0578604	True
 60	1987	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050978	Shoeshine	tt0093960	Robert A. Katz, Producer	Robert A. Katz	nm0441831
-60	1987	Production	SOUND	SOUND	an0050950	Empire of the Sun	tt0092965	Robert Knudson, Don Digirolamo, John Boyd, Tony Dawe	Robert Knudson, Don Digirolamo, John Boyd, Tony Dawe	nm0461702,nm0226564,nm0101815,nm0003360
-60	1987	Production	SOUND	SOUND	an0050949	The Last Emperor	tt0093389	Bill Rowe, Ivan Sharrock	Bill Rowe, Ivan Sharrock	nm0746477,nm0789331	True
-60	1987	Production	SOUND	SOUND	an0050951	Lethal Weapon	tt0093409	Les Fresholtz, Dick Alexander, Vern Poore, Bill Nelson	Les Fresholtz, Dick Alexander, Vern Poore, Bill Nelson	nm0294370,nm1219804,nm0691005,nm0625179
-60	1987	Production	SOUND	SOUND	an0050952	RoboCop	tt0093870	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Robert Wald	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Robert Wald	nm0463489,nm0216467,nm0734099,nm0907016
-60	1987	Production	SOUND	SOUND	an0050953	The Witches of Eastwick	tt0094332	Wayne Artman, Tom Beckert, Tom Dahl, Art Rochester	Wayne Artman, Tom Beckert, Tom Dahl, Art Rochester	nm0037923,nm0065657,nm0196980,nm0734053
+60	1987	Production	SOUND MIXING	SOUND	an0050950	Empire of the Sun	tt0092965	Robert Knudson, Don Digirolamo, John Boyd, Tony Dawe	Robert Knudson, Don Digirolamo, John Boyd, Tony Dawe	nm0461702,nm0226564,nm0101815,nm0003360
+60	1987	Production	SOUND MIXING	SOUND	an0050949	The Last Emperor	tt0093389	Bill Rowe, Ivan Sharrock	Bill Rowe, Ivan Sharrock	nm0746477,nm0789331	True
+60	1987	Production	SOUND MIXING	SOUND	an0050951	Lethal Weapon	tt0093409	Les Fresholtz, Dick Alexander, Vern Poore, Bill Nelson	Les Fresholtz, Dick Alexander, Vern Poore, Bill Nelson	nm0294370,nm1219804,nm0691005,nm0625179
+60	1987	Production	SOUND MIXING	SOUND	an0050952	RoboCop	tt0093870	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Robert Wald	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Robert Wald	nm0463489,nm0216467,nm0734099,nm0907016
+60	1987	Production	SOUND MIXING	SOUND	an0050953	The Witches of Eastwick	tt0094332	Wayne Artman, Tom Beckert, Tom Dahl, Art Rochester	Wayne Artman, Tom Beckert, Tom Dahl, Art Rochester	nm0037923,nm0065657,nm0196980,nm0734053
 60	1987	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0050959	Innerspace	tt0093260	Dennis Muren, William George, Harley Jessup, Kenneth Smith	Dennis Muren, William George, Harley Jessup, Kenneth Smith	nm0613830,nm0313357,nm0422263,nm0808946	True
 60	1987	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0050960	Predator	tt0093773	Joel Hynek, Robert M. Greenberg, Richard Greenberg, Stan Winston	Joel Hynek, Robert M. Greenberg, Richard Greenberg, Stan Winston	nm0006699,nm0338581,nm0338572,nm0935644
 60	1987	Writing	WRITING (Adapted Screenplay)	WRITING (Screenplay Based on Material from Another Medium)	an0050930	The Dead	tt0092843	Tony Huston	Tony Huston	nm0404154
@@ -7202,11 +7202,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 61	1988	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0054381	The Appointments of Dennis Jennings	tt0094670	Dean Parisot, Steven Wright	Dean Parisot, Steven Wright	nm0661751,nm0942833	True
 61	1988	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0054382	Cadillac Dreams	tt0094825	Matia Karrell, Abbee Goldstein	Matia Karrell, Abbee Goldstein	nm0440105,nm0326152
 61	1988	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0054383	Gullah Tales	tt0095261	George deGolian, Gary Moss	George deGolian, Gary Moss	nm1480937,nm0608965
-61	1988	Production	SOUND	SOUND	an0054351	Bird	tt0094747	Les Fresholtz, Dick Alexander, Vern Poore, Willie D. Burton	Les Fresholtz, Dick Alexander, Vern Poore, Willie D. Burton	nm0294370,nm1219804,nm0691005,nm0123770	True
-61	1988	Production	SOUND	SOUND	an0054352	Die Hard	tt0095016	Don Bassman, Kevin F. Cleary, Richard Overton, Al Overton	Don Bassman, Kevin F. Cleary, Richard Overton, Al Overton	nm0060318,nm0165855,nm0653958,nm0653929
-61	1988	Production	SOUND	SOUND	an0054353	Gorillas in the Mist	tt0095243	Andy Nelson, Brian Saunders, Peter Handford	Andy Nelson, Brian Saunders, Peter Handford	nm0625144,nm0766750,nm0359542
-61	1988	Production	SOUND	SOUND	an0054354	Mississippi Burning	tt0095647	Robert Litt, Elliot Tyson, Rick Kline, Danny Michael	Robert Litt, Elliot Tyson, Rick Kline, Danny Michael	nm0514448,nm0006525,nm0459662,nm0584098
-61	1988	Production	SOUND	SOUND	an0054355	Who Framed Roger Rabbit	tt0096438	Robert Knudson, John Boyd, Don Digirolamo, Tony Dawe	Robert Knudson, John Boyd, Don Digirolamo, Tony Dawe	nm0461702,nm0101815,nm0226564,nm0003360
+61	1988	Production	SOUND MIXING	SOUND	an0054351	Bird	tt0094747	Les Fresholtz, Dick Alexander, Vern Poore, Willie D. Burton	Les Fresholtz, Dick Alexander, Vern Poore, Willie D. Burton	nm0294370,nm1219804,nm0691005,nm0123770	True
+61	1988	Production	SOUND MIXING	SOUND	an0054352	Die Hard	tt0095016	Don Bassman, Kevin F. Cleary, Richard Overton, Al Overton	Don Bassman, Kevin F. Cleary, Richard Overton, Al Overton	nm0060318,nm0165855,nm0653958,nm0653929
+61	1988	Production	SOUND MIXING	SOUND	an0054353	Gorillas in the Mist	tt0095243	Andy Nelson, Brian Saunders, Peter Handford	Andy Nelson, Brian Saunders, Peter Handford	nm0625144,nm0766750,nm0359542
+61	1988	Production	SOUND MIXING	SOUND	an0054354	Mississippi Burning	tt0095647	Robert Litt, Elliot Tyson, Rick Kline, Danny Michael	Robert Litt, Elliot Tyson, Rick Kline, Danny Michael	nm0514448,nm0006525,nm0459662,nm0584098
+61	1988	Production	SOUND MIXING	SOUND	an0054355	Who Framed Roger Rabbit	tt0096438	Robert Knudson, John Boyd, Don Digirolamo, Tony Dawe	Robert Knudson, John Boyd, Don Digirolamo, Tony Dawe	nm0461702,nm0101815,nm0226564,nm0003360
 61	1988	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0054362	Die Hard	tt0095016	Stephen H. Flick, Richard Shorr	Stephen H. Flick, Richard Shorr	nm0282276,nm0795015
 61	1988	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0054361	Who Framed Roger Rabbit	tt0096438	Charles L. Campbell, Louis L. Edemann	Charles L. Campbell, Louis L. Edemann	nm0132287,nm0249068	True
 61	1988	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0054363	Willow	tt0096446	Ben Burtt, Richard Hymns	Ben Burtt, Richard Hymns	nm0123785,nm0405232
@@ -7324,11 +7324,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 62	1989	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052794	Amazon Diary	tt0096798	Robert Nixon	Robert Nixon	nm0633272
 62	1989	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052795	The Childeater	tt0097057	Jonathan Tammuz	Jonathan Tammuz	nm0848734
 62	1989	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0052793	Work Experience	tt0098677	James Hendrie	James Hendrie	nm0376835	True
-62	1989	Production	SOUND	SOUND	an0052762	The Abyss	tt0096754	Don Bassman, Kevin F. Cleary, Richard Overton, Lee Orloff	Don Bassman, Kevin F. Cleary, Richard Overton, Lee Orloff	nm0060318,nm0165855,nm0653958,nm0650090
-62	1989	Production	SOUND	SOUND	an0052763	Black Rain	tt0096933	Donald O. Mitchell, Kevin O'Connell, Greg P. Russell, Keith A. Wester	Donald O. Mitchell, Kevin O'Connell, Greg P. Russell, Keith A. Wester	nm0593290,nm0640114,nm0751169,nm0199492
-62	1989	Production	SOUND	SOUND	an0052764	Born on the Fourth of July	tt0096969	Michael Minkler, Gregory H. Watkins, Wylie Stateman, Tod A. Maitland	Michael Minkler, Gregory H. Watkins, Wylie Stateman, Tod A. Maitland	nm0591444,nm0914312,nm0823758,nm0537972
-62	1989	Production	SOUND	SOUND	an0052761	Glory	tt0097441	Donald O. Mitchell, Gregg C. Rudloff, Elliot Tyson, Russell Williams II	Donald O. Mitchell, Gregg C. Rudloff, Elliot Tyson, Russell Williams II	nm0593290,nm0748832,nm0006525,nm0007020	True
-62	1989	Production	SOUND	SOUND	an0052765	Indiana Jones and the Last Crusade	tt0097576	Ben Burtt, Gary Summers, Shawn Murphy, Tony Dawe	Ben Burtt, Gary Summers, Shawn Murphy, Tony Dawe	nm0123785,nm0838707,nm0004156,nm0003360
+62	1989	Production	SOUND MIXING	SOUND	an0052762	The Abyss	tt0096754	Don Bassman, Kevin F. Cleary, Richard Overton, Lee Orloff	Don Bassman, Kevin F. Cleary, Richard Overton, Lee Orloff	nm0060318,nm0165855,nm0653958,nm0650090
+62	1989	Production	SOUND MIXING	SOUND	an0052763	Black Rain	tt0096933	Donald O. Mitchell, Kevin O'Connell, Greg P. Russell, Keith A. Wester	Donald O. Mitchell, Kevin O'Connell, Greg P. Russell, Keith A. Wester	nm0593290,nm0640114,nm0751169,nm0199492
+62	1989	Production	SOUND MIXING	SOUND	an0052764	Born on the Fourth of July	tt0096969	Michael Minkler, Gregory H. Watkins, Wylie Stateman, Tod A. Maitland	Michael Minkler, Gregory H. Watkins, Wylie Stateman, Tod A. Maitland	nm0591444,nm0914312,nm0823758,nm0537972
+62	1989	Production	SOUND MIXING	SOUND	an0052761	Glory	tt0097441	Donald O. Mitchell, Gregg C. Rudloff, Elliot Tyson, Russell Williams II	Donald O. Mitchell, Gregg C. Rudloff, Elliot Tyson, Russell Williams II	nm0593290,nm0748832,nm0006525,nm0007020	True
+62	1989	Production	SOUND MIXING	SOUND	an0052765	Indiana Jones and the Last Crusade	tt0097576	Ben Burtt, Gary Summers, Shawn Murphy, Tony Dawe	Ben Burtt, Gary Summers, Shawn Murphy, Tony Dawe	nm0123785,nm0838707,nm0004156,nm0003360
 62	1989	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0052772	Black Rain	tt0096933	Milton C. Burrow, William L. Manger	Milton C. Burrow, William L. Manger	nm0123228,nm0542191
 62	1989	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0052771	Indiana Jones and the Last Crusade	tt0097576	Ben Burtt, Richard Hymns	Ben Burtt, Richard Hymns	nm0123785,nm0405232	True
 62	1989	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0052773	Lethal Weapon 2	tt0097733	Robert Henderson, Alan Robert Murray	Robert Henderson, Alan Robert Murray	nm0376583,nm0614812
@@ -7442,11 +7442,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 63	1990	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053156	The Lunch Date	tt0100076	Adam Davidson	Adam Davidson	nm0203215	True
 63	1990	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053159	Senzeni Na? (What Have We Done?)	tt0100579	Bernard Joffa, Anthony E. Nicholas	Bernard Joffa, Anthony E. Nicholas	nm0423615,nm0629356
 63	1990	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053160	12:01 PM	tt0098962	Hillary Ripps, Jonathan Heap	Hillary Ripps, Jonathan Heap	nm0728123,nm0372421
-63	1990	Production	SOUND	SOUND	an0053127	Dances With Wolves	tt0099348	Jeffrey Perkins, Bill W. Benton, Greg Watkins, Russell Williams II	Jeffrey Perkins, Bill W. Benton, Greg Watkins, Russell Williams II	nm0673964,nm0072904,nm0914312,nm0007020	True
-63	1990	Production	SOUND	SOUND	an0053128	Days of Thunder	tt0099371	Donald O. Mitchell, Rick Kline, Kevin O'Connell, Charles Wilborn	Donald O. Mitchell, Rick Kline, Kevin O'Connell, Charles Wilborn	nm0593290,nm0459662,nm0640114,nm0928088
-63	1990	Production	SOUND	SOUND	an0053129	Dick Tracy	tt0099422	Chris Jenkins, David E. Campbell, D. M. Hemphill, Thomas Causey	Chris Jenkins, David E. Campbell, D. M. Hemphill, Thomas Causey	nm0420804,nm0132372,nm0376153,nm0146600
-63	1990	Production	SOUND	SOUND	an0053130	The Hunt for Red October	tt0099810	Don Bassman, Richard Overton, Kevin F. Cleary, Richard Bryce Goodman	Don Bassman, Richard Overton, Kevin F. Cleary, Richard Bryce Goodman	nm0060318,nm0653958,nm0165855,nm0329208
-63	1990	Production	SOUND	SOUND	an0053131	Total Recall	tt0100802	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Nelson Stoll	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Nelson Stoll	nm0463489,nm0216467,nm0734099,nm0831523
+63	1990	Production	SOUND MIXING	SOUND	an0053127	Dances With Wolves	tt0099348	Jeffrey Perkins, Bill W. Benton, Greg Watkins, Russell Williams II	Jeffrey Perkins, Bill W. Benton, Greg Watkins, Russell Williams II	nm0673964,nm0072904,nm0914312,nm0007020	True
+63	1990	Production	SOUND MIXING	SOUND	an0053128	Days of Thunder	tt0099371	Donald O. Mitchell, Rick Kline, Kevin O'Connell, Charles Wilborn	Donald O. Mitchell, Rick Kline, Kevin O'Connell, Charles Wilborn	nm0593290,nm0459662,nm0640114,nm0928088
+63	1990	Production	SOUND MIXING	SOUND	an0053129	Dick Tracy	tt0099422	Chris Jenkins, David E. Campbell, D. M. Hemphill, Thomas Causey	Chris Jenkins, David E. Campbell, D. M. Hemphill, Thomas Causey	nm0420804,nm0132372,nm0376153,nm0146600
+63	1990	Production	SOUND MIXING	SOUND	an0053130	The Hunt for Red October	tt0099810	Don Bassman, Richard Overton, Kevin F. Cleary, Richard Bryce Goodman	Don Bassman, Richard Overton, Kevin F. Cleary, Richard Bryce Goodman	nm0060318,nm0653958,nm0165855,nm0329208
+63	1990	Production	SOUND MIXING	SOUND	an0053131	Total Recall	tt0100802	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Nelson Stoll	Michael J. Kohut, Carlos de Larios, Aaron Rochin, Nelson Stoll	nm0463489,nm0216467,nm0734099,nm0831523
 63	1990	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0053138	Flatliners	tt0099582	Charles L. Campbell, Richard Franklin	Charles L. Campbell, Richard Franklin	nm0132287,nm0291526
 63	1990	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0053137	The Hunt for Red October	tt0099810	Cecelia Hall, George Watters II	Cecelia Hall, George Watters II	nm0355398,nm0915036	True
 63	1990	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0053139	Total Recall	tt0100802	Stephen H. Flick	Stephen H. Flick	nm0282276
@@ -7568,11 +7568,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 64	1991	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049519	Birch Street Gym	tt0101456	Stephen Kessler, Thomas R. Conroy	Stephen Kessler, Thomas R. Conroy	nm0450387,nm0175865
 64	1991	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049520	Last Breeze of Summer	tt0102268	David M. Massey	David M. Massey	nm0557294
 64	1991	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049518	Session Man	tt0108086	Seth Winston, Rob Fried	Seth Winston, Rob Fried	nm0935641,nm0294975	True
-64	1991	Production	SOUND	SOUND	an0385033	Backdraft	tt0101393	Gary Summers, Randy Thom, Gary Rydstrom, Glenn Williams	Gary Summers, Randy Thom, Gary Rydstrom, Glenn Williams	nm0838707,nm0858378,nm0003977,nm1491296
-64	1991	Production	SOUND	SOUND	an0049488	Beauty and the Beast	tt0101414	Terry Porter, Mel Metcalfe, David J. Hudson, Doc Kane	Terry Porter, Mel Metcalfe, David J. Hudson, Doc Kane	nm0692310,nm0582467,nm0399812,nm0437301
-64	1991	Production	SOUND	SOUND	an0049489	JFK	tt0102138	Michael Minkler, Gregg Landaker, Tod A. Maitland	Michael Minkler, Gregg Landaker, Tod A. Maitland	nm0591444,nm0484414,nm0537972
-64	1991	Production	SOUND	SOUND	an0049490	The Silence of the Lambs	tt0102926	Tom Fleischman, Christopher Newman	Tom Fleischman, Christopher Newman	nm0281530,nm0628039
-64	1991	Production	SOUND	SOUND	an0049486	Terminator 2: Judgment Day	tt0103064	Tom Johnson, Gary Rydstrom, Gary Summers, Lee Orloff	Tom Johnson, Gary Rydstrom, Gary Summers, Lee Orloff	nm0426348,nm0003977,nm0838707,nm0650090	True
+64	1991	Production	SOUND MIXING	SOUND	an0385033	Backdraft	tt0101393	Gary Summers, Randy Thom, Gary Rydstrom, Glenn Williams	Gary Summers, Randy Thom, Gary Rydstrom, Glenn Williams	nm0838707,nm0858378,nm0003977,nm1491296
+64	1991	Production	SOUND MIXING	SOUND	an0049488	Beauty and the Beast	tt0101414	Terry Porter, Mel Metcalfe, David J. Hudson, Doc Kane	Terry Porter, Mel Metcalfe, David J. Hudson, Doc Kane	nm0692310,nm0582467,nm0399812,nm0437301
+64	1991	Production	SOUND MIXING	SOUND	an0049489	JFK	tt0102138	Michael Minkler, Gregg Landaker, Tod A. Maitland	Michael Minkler, Gregg Landaker, Tod A. Maitland	nm0591444,nm0484414,nm0537972
+64	1991	Production	SOUND MIXING	SOUND	an0049490	The Silence of the Lambs	tt0102926	Tom Fleischman, Christopher Newman	Tom Fleischman, Christopher Newman	nm0281530,nm0628039
+64	1991	Production	SOUND MIXING	SOUND	an0049486	Terminator 2: Judgment Day	tt0103064	Tom Johnson, Gary Rydstrom, Gary Summers, Lee Orloff	Tom Johnson, Gary Rydstrom, Gary Summers, Lee Orloff	nm0426348,nm0003977,nm0838707,nm0650090	True
 64	1991	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049497	Backdraft	tt0101393	Gary Rydstrom, Richard Hymns	Gary Rydstrom, Richard Hymns	nm0003977,nm0405232
 64	1991	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049498	Star Trek VI The Undiscovered Country	tt0102975	George Watters II, F. Hudson Miller	George Watters II, F. Hudson Miller	nm0915036,nm0588326
 64	1991	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049496	Terminator 2: Judgment Day	tt0103064	Gary Rydstrom, Gloria S. Borders	Gary Rydstrom, Gloria S. Borders	nm0003977,nm0096187	True
@@ -7697,11 +7697,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 65	1992	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050410	The Lady in Waiting	tt0104669	Christian M. Taylor	Christian M. Taylor	nm0995597
 65	1992	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050407	Omnibus	tt0105051	Sam Karmann	Sam Karmann	nm0439748	True
 65	1992	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050411	Swan Song	tt0105506	Kenneth Branagh, David Parfitt	Kenneth Branagh, David Parfitt	nm0000110,nm0661406
-65	1992	Production	SOUND	SOUND	an0050374	Aladdin	tt0103639	Terry Porter, Mel Metcalfe, David J. Hudson, Doc Kane	Terry Porter, Mel Metcalfe, David J. Hudson, Doc Kane	nm0692310,nm0582467,nm0399812,nm0437301
-65	1992	Production	SOUND	SOUND	an0050375	A Few Good Men	tt0104257	Kevin O'Connell, Rick Kline, Bob Eber	Kevin O'Connell, Rick Kline, Bob Eber	nm0640114,nm0459662,nm0248024
-65	1992	Production	SOUND	SOUND	an0050373	The Last of the Mohicans	tt0104691	Chris Jenkins, Doug Hemphill, Mark Smith, Simon Kaye	Chris Jenkins, Doug Hemphill, Mark Smith, Simon Kaye	nm0420804,nm0376153,nm0809234,nm0443393	True
-65	1992	Production	SOUND	SOUND	an0050376	Under Siege	tt0105690	Don Mitchell, Frank A. Montaño, Rick Hart, Scott Smith	Don Mitchell, Frank A. Montaño, Rick Hart, Scott Smith	nm0593290,nm0599057,nm0366494,nm0809896
-65	1992	Production	SOUND	SOUND	an0050377	Unforgiven	tt0105695	Les Fresholtz, Vern Poore, Dick Alexander, Rob Young	Les Fresholtz, Vern Poore, Dick Alexander, Rob Young	nm0294370,nm0691005,nm1219804,nm0949997
+65	1992	Production	SOUND MIXING	SOUND	an0050374	Aladdin	tt0103639	Terry Porter, Mel Metcalfe, David J. Hudson, Doc Kane	Terry Porter, Mel Metcalfe, David J. Hudson, Doc Kane	nm0692310,nm0582467,nm0399812,nm0437301
+65	1992	Production	SOUND MIXING	SOUND	an0050375	A Few Good Men	tt0104257	Kevin O'Connell, Rick Kline, Bob Eber	Kevin O'Connell, Rick Kline, Bob Eber	nm0640114,nm0459662,nm0248024
+65	1992	Production	SOUND MIXING	SOUND	an0050373	The Last of the Mohicans	tt0104691	Chris Jenkins, Doug Hemphill, Mark Smith, Simon Kaye	Chris Jenkins, Doug Hemphill, Mark Smith, Simon Kaye	nm0420804,nm0376153,nm0809234,nm0443393	True
+65	1992	Production	SOUND MIXING	SOUND	an0050376	Under Siege	tt0105690	Don Mitchell, Frank A. Montaño, Rick Hart, Scott Smith	Don Mitchell, Frank A. Montaño, Rick Hart, Scott Smith	nm0593290,nm0599057,nm0366494,nm0809896
+65	1992	Production	SOUND MIXING	SOUND	an0050377	Unforgiven	tt0105695	Les Fresholtz, Vern Poore, Dick Alexander, Rob Young	Les Fresholtz, Vern Poore, Dick Alexander, Rob Young	nm0294370,nm0691005,nm1219804,nm0949997
 65	1992	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0050384	Aladdin	tt0103639	Mark Mangini	Mark Mangini	nm0005625
 65	1992	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0050383	Bram Stoker's Dracula	tt0103874	Tom C. McCarthy, David E. Stone	Tom C. McCarthy, David E. Stone	nm0565344,nm0831823	True
 65	1992	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0050385	Under Siege	tt0105690	John Leveque, Bruce Stambler	John Leveque, Bruce Stambler	nm0505311,nm0821801
@@ -7821,11 +7821,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 66	1993	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049126	The Dutch Master	tt0112917	Susan Seidelman, Jonathan Brett	Susan Seidelman, Jonathan Brett	nm0782384,nm0107954
 66	1993	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049127	Partners	tt0110781	Peter Weller, Jana Sue Memel	Peter Weller, Jana Sue Memel	nm0000693,nm0578604
 66	1993	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0049128	The Screw (La Vis)	tt0108498	Didier Flamand	Didier Flamand	nm0280955
-66	1993	Production	SOUND	SOUND	an0049091	Cliffhanger	tt0106582	Michael Minkler, Bob Beemer, Tim Cooney	Michael Minkler, Bob Beemer, Tim Cooney	nm0591444,nm0066446,nm0177784
-66	1993	Production	SOUND	SOUND	an0049092	The Fugitive	tt0106977	Donald O. Mitchell, Michael Herbick, Frank A. Montaño, Scott D. Smith	Donald O. Mitchell, Michael Herbick, Frank A. Montaño, Scott D. Smith	nm0593290,nm0378655,nm0599057,nm0809896
-66	1993	Production	SOUND	SOUND	an0049093	Geronimo: An American Legend	tt0107004	Chris Carpenter, D. M. Hemphill, Bill W. Benton, Lee Orloff	Chris Carpenter, D. M. Hemphill, Bill W. Benton, Lee Orloff	nm0139303,nm0376153,nm0072904,nm0650090
-66	1993	Production	SOUND	SOUND	an0049090	Jurassic Park	tt0107290	Gary Summers, Gary Rydstrom, Shawn Murphy, Ron Judkins	Gary Summers, Gary Rydstrom, Shawn Murphy, Ron Judkins	nm0838707,nm0003977,nm0004156,nm0431954	True
-66	1993	Production	SOUND	SOUND	an0049094	Schindler's List	tt0108052	Andy Nelson, Steve Pederson, Scott Millan, Ron Judkins	Andy Nelson, Steve Pederson, Scott Millan, Ron Judkins	nm0625144,nm0670007,nm0586793,nm0431954
+66	1993	Production	SOUND MIXING	SOUND	an0049091	Cliffhanger	tt0106582	Michael Minkler, Bob Beemer, Tim Cooney	Michael Minkler, Bob Beemer, Tim Cooney	nm0591444,nm0066446,nm0177784
+66	1993	Production	SOUND MIXING	SOUND	an0049092	The Fugitive	tt0106977	Donald O. Mitchell, Michael Herbick, Frank A. Montaño, Scott D. Smith	Donald O. Mitchell, Michael Herbick, Frank A. Montaño, Scott D. Smith	nm0593290,nm0378655,nm0599057,nm0809896
+66	1993	Production	SOUND MIXING	SOUND	an0049093	Geronimo: An American Legend	tt0107004	Chris Carpenter, D. M. Hemphill, Bill W. Benton, Lee Orloff	Chris Carpenter, D. M. Hemphill, Bill W. Benton, Lee Orloff	nm0139303,nm0376153,nm0072904,nm0650090
+66	1993	Production	SOUND MIXING	SOUND	an0049090	Jurassic Park	tt0107290	Gary Summers, Gary Rydstrom, Shawn Murphy, Ron Judkins	Gary Summers, Gary Rydstrom, Shawn Murphy, Ron Judkins	nm0838707,nm0003977,nm0004156,nm0431954	True
+66	1993	Production	SOUND MIXING	SOUND	an0049094	Schindler's List	tt0108052	Andy Nelson, Steve Pederson, Scott Millan, Ron Judkins	Andy Nelson, Steve Pederson, Scott Millan, Ron Judkins	nm0625144,nm0670007,nm0586793,nm0431954
 66	1993	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049101	Cliffhanger	tt0106582	Wylie Stateman, Gregg Baxter	Wylie Stateman, Gregg Baxter	nm0823758,nm0062741
 66	1993	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049102	The Fugitive	tt0106977	John Leveque, Bruce Stambler	John Leveque, Bruce Stambler	nm0505311,nm0821801
 66	1993	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0049100	Jurassic Park	tt0107290	Gary Rydstrom, Richard Hymns	Gary Rydstrom, Richard Hymns	nm0003977,nm0405232	True
@@ -7942,11 +7942,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 67	1994	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053277	On Hope	tt0110726	JoBeth Williams, Michele McGuire	JoBeth Williams, Michele McGuire	nm0001851,nm0570266
 67	1994	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053278	Syrup	tt0111338	Paul Unwin, Nick Vivian	Paul Unwin, Nick Vivian	nm0881391,nm0900327
 67	1994	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0053275	Trevor	tt0111486	Peggy Rajski, Randy Stone	Peggy Rajski, Randy Stone	nm0707475,nm0832114	True		NOTE: A tie. The other winning film in this category was Franz Kafka's It's a Wonderful Life.
-67	1994	Production	SOUND	SOUND	an0053241	Clear and Present Danger	tt0109444	Donald O. Mitchell, Michael Herbick, Frank A. Montaño, Arthur Rochester	Donald O. Mitchell, Michael Herbick, Frank A. Montaño, Arthur Rochester	nm0593290,nm0378655,nm0599057,nm0734053
-67	1994	Production	SOUND	SOUND	an0053242	Forrest Gump	tt0109830	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	nm0858378,nm0426348,nm0762304,nm0438202
-67	1994	Production	SOUND	SOUND	an0053243	Legends of the Fall	tt0110322	Paul Massey, David Campbell, Christopher David, Douglas Ganton	Paul Massey, David Campbell, Christopher David, Douglas Ganton	nm0557338,nm0132372,nm0202845,nm0304618
-67	1994	Production	SOUND	SOUND	an0053244	The Shawshank Redemption	tt0111161	Robert J. Litt, Elliot Tyson, Michael Herbick, Willie Burton	Robert J. Litt, Elliot Tyson, Michael Herbick, Willie Burton	nm0514448,nm0006525,nm0378655,nm0123770
-67	1994	Production	SOUND	SOUND	an0053240	Speed	tt0111257	Gregg Landaker, Steve Maslow, Bob Beemer, David R. B. MacMillan	Gregg Landaker, Steve Maslow, Bob Beemer, David R. B. MacMillan	nm0484414,nm0556541,nm0066446,nm0533997	True
+67	1994	Production	SOUND MIXING	SOUND	an0053241	Clear and Present Danger	tt0109444	Donald O. Mitchell, Michael Herbick, Frank A. Montaño, Arthur Rochester	Donald O. Mitchell, Michael Herbick, Frank A. Montaño, Arthur Rochester	nm0593290,nm0378655,nm0599057,nm0734053
+67	1994	Production	SOUND MIXING	SOUND	an0053242	Forrest Gump	tt0109830	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	nm0858378,nm0426348,nm0762304,nm0438202
+67	1994	Production	SOUND MIXING	SOUND	an0053243	Legends of the Fall	tt0110322	Paul Massey, David Campbell, Christopher David, Douglas Ganton	Paul Massey, David Campbell, Christopher David, Douglas Ganton	nm0557338,nm0132372,nm0202845,nm0304618
+67	1994	Production	SOUND MIXING	SOUND	an0053244	The Shawshank Redemption	tt0111161	Robert J. Litt, Elliot Tyson, Michael Herbick, Willie Burton	Robert J. Litt, Elliot Tyson, Michael Herbick, Willie Burton	nm0514448,nm0006525,nm0378655,nm0123770
+67	1994	Production	SOUND MIXING	SOUND	an0053240	Speed	tt0111257	Gregg Landaker, Steve Maslow, Bob Beemer, David R. B. MacMillan	Gregg Landaker, Steve Maslow, Bob Beemer, David R. B. MacMillan	nm0484414,nm0556541,nm0066446,nm0533997	True
 67	1994	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0053251	Clear and Present Danger	tt0109444	Bruce Stambler, John Leveque	Bruce Stambler, John Leveque	nm0821801,nm0505311
 67	1994	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0053252	Forrest Gump	tt0109830	Gloria S. Borders, Randy Thom	Gloria S. Borders, Randy Thom	nm0096187,nm0858378
 67	1994	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0053250	Speed	tt0111257	Stephen Hunter Flick	Stephen Hunter Flick	nm0282276	True
@@ -8085,11 +8085,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 68	1995	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051191	Lieberman in Love	tt0113653	Christine Lahti, Jana Sue Memel	Christine Lahti, Jana Sue Memel	nm0001441,nm0578604	True
 68	1995	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051194	Little Surprises	tt0113671	Jeff Goldblum, Tikki Goldberg	Jeff Goldblum, Tikki Goldberg	nm0000156,nm0325324
 68	1995	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0051195	Tuesday Morning Ride	tt0114742	Dianne Houston, Joy Ryan	Dianne Houston, Joy Ryan	nm0396817,nm0752641
-68	1995	Production	SOUND	SOUND	an0051153	Apollo 13	tt0112384	Rick Dior, Steve Pederson, Scott Millan, David MacMillan	Rick Dior, Steve Pederson, Scott Millan, David MacMillan	nm0228047,nm0670007,nm0586793,nm0533997	True
-68	1995	Production	SOUND	SOUND	an0051154	Batman Forever	tt0112462	Donald O. Mitchell, Frank A. Montaño, Michael Herbick, Petur Hliddal	Donald O. Mitchell, Frank A. Montaño, Michael Herbick, Petur Hliddal	nm0593290,nm0599057,nm0378655,nm0387213
-68	1995	Production	SOUND	SOUND	an0051155	Braveheart	tt0112573	Andy Nelson, Scott Millan, Anna Behlmer, Brian Simmons	Andy Nelson, Scott Millan, Anna Behlmer, Brian Simmons	nm0625144,nm0586793,nm0066933,nm0799694
-68	1995	Production	SOUND	SOUND	an0051156	Crimson Tide	tt0112740	Kevin O'Connell, Rick Kline, Gregory H. Watkins, William B. Kaplan	Kevin O'Connell, Rick Kline, Gregory H. Watkins, William B. Kaplan	nm0640114,nm0459662,nm0914312,nm0438202
-68	1995	Production	SOUND	SOUND	an0051157	Waterworld	tt0114898	Steve Maslow, Gregg Landaker, Keith A. Wester	Steve Maslow, Gregg Landaker, Keith A. Wester	nm0556541,nm0484414,nm0199492
+68	1995	Production	SOUND MIXING	SOUND	an0051153	Apollo 13	tt0112384	Rick Dior, Steve Pederson, Scott Millan, David MacMillan	Rick Dior, Steve Pederson, Scott Millan, David MacMillan	nm0228047,nm0670007,nm0586793,nm0533997	True
+68	1995	Production	SOUND MIXING	SOUND	an0051154	Batman Forever	tt0112462	Donald O. Mitchell, Frank A. Montaño, Michael Herbick, Petur Hliddal	Donald O. Mitchell, Frank A. Montaño, Michael Herbick, Petur Hliddal	nm0593290,nm0599057,nm0378655,nm0387213
+68	1995	Production	SOUND MIXING	SOUND	an0051155	Braveheart	tt0112573	Andy Nelson, Scott Millan, Anna Behlmer, Brian Simmons	Andy Nelson, Scott Millan, Anna Behlmer, Brian Simmons	nm0625144,nm0586793,nm0066933,nm0799694
+68	1995	Production	SOUND MIXING	SOUND	an0051156	Crimson Tide	tt0112740	Kevin O'Connell, Rick Kline, Gregory H. Watkins, William B. Kaplan	Kevin O'Connell, Rick Kline, Gregory H. Watkins, William B. Kaplan	nm0640114,nm0459662,nm0914312,nm0438202
+68	1995	Production	SOUND MIXING	SOUND	an0051157	Waterworld	tt0114898	Steve Maslow, Gregg Landaker, Keith A. Wester	Steve Maslow, Gregg Landaker, Keith A. Wester	nm0556541,nm0484414,nm0199492
 68	1995	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0051164	Batman Forever	tt0112462	John Leveque, Bruce Stambler	John Leveque, Bruce Stambler	nm0505311,nm0821801
 68	1995	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0051163	Braveheart	tt0112573	Lon Bender, Per Hallberg	Lon Bender, Per Hallberg	nm0070489,nm0356319	True
 68	1995	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0051165	Crimson Tide	tt0112740	George Watters II	George Watters II	nm0915036
@@ -8224,11 +8224,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 69	1996	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0047850	Ernst & Lyset	tt0116214	Kim Magnusson, Anders Thomas Jensen	Kim Magnusson, Anders Thomas Jensen	nm0536385,nm0421314
 69	1996	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0047851	Esposados	tt0116233	Juan Carlos Fresnadillo	Juan Carlos Fresnadillo	nm0294379
 69	1996	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0047852	Wordless	tt0118191	Bernadette Carranza, Antonello De Leo	Bernadette Carranza, Antonello De Leo	nm0139979,nm0209633
-69	1996	Production	SOUND	SOUND	an0047810	The English Patient	tt0116209	Walter Murch, Mark Berger, David Parker, Chris Newman	Walter Murch, Mark Berger, David Parker, Chris Newman	nm0004555,nm0074281,nm0662188,nm0628039	True
-69	1996	Production	SOUND	SOUND	an0047811	Evita	tt0116250	Andy Nelson, Anna Behlmer, Ken Weston	Andy Nelson, Anna Behlmer, Ken Weston	nm0625144,nm0066933,nm0922984
-69	1996	Production	SOUND	SOUND	an0047812	Independence Day	tt0116629	Chris Carpenter, Bill W. Benton, Bob Beemer, Jeff Wexler	Chris Carpenter, Bill W. Benton, Bob Beemer, Jeff Wexler	nm0139303,nm0072904,nm0066446,nm0923306
-69	1996	Production	SOUND	SOUND	an0047813	The Rock	tt0117500	Kevin O'Connell, Greg P. Russell, Keith A. Wester	Kevin O'Connell, Greg P. Russell, Keith A. Wester	nm0640114,nm0751169,nm0199492
-69	1996	Production	SOUND	SOUND	an0047814	Twister	tt0117998	Steve Maslow, Gregg Landaker, Kevin O'Connell, Geoffrey Patterson	Steve Maslow, Gregg Landaker, Kevin O'Connell, Geoffrey Patterson	nm0556541,nm0484414,nm0640114,nm0666215
+69	1996	Production	SOUND MIXING	SOUND	an0047810	The English Patient	tt0116209	Walter Murch, Mark Berger, David Parker, Chris Newman	Walter Murch, Mark Berger, David Parker, Chris Newman	nm0004555,nm0074281,nm0662188,nm0628039	True
+69	1996	Production	SOUND MIXING	SOUND	an0047811	Evita	tt0116250	Andy Nelson, Anna Behlmer, Ken Weston	Andy Nelson, Anna Behlmer, Ken Weston	nm0625144,nm0066933,nm0922984
+69	1996	Production	SOUND MIXING	SOUND	an0047812	Independence Day	tt0116629	Chris Carpenter, Bill W. Benton, Bob Beemer, Jeff Wexler	Chris Carpenter, Bill W. Benton, Bob Beemer, Jeff Wexler	nm0139303,nm0072904,nm0066446,nm0923306
+69	1996	Production	SOUND MIXING	SOUND	an0047813	The Rock	tt0117500	Kevin O'Connell, Greg P. Russell, Keith A. Wester	Kevin O'Connell, Greg P. Russell, Keith A. Wester	nm0640114,nm0751169,nm0199492
+69	1996	Production	SOUND MIXING	SOUND	an0047814	Twister	tt0117998	Steve Maslow, Gregg Landaker, Kevin O'Connell, Geoffrey Patterson	Steve Maslow, Gregg Landaker, Kevin O'Connell, Geoffrey Patterson	nm0556541,nm0484414,nm0640114,nm0666215
 69	1996	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0047821	Daylight	tt0116040	Richard L. Anderson, David A. Whittaker	Richard L. Anderson, David A. Whittaker	nm0027328,nm0926422
 69	1996	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0047822	Eraser	tt0116213	Alan Robert Murray, Bub Asman	Alan Robert Murray, Bub Asman	nm0614812,nm0039544
 69	1996	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0047820	The Ghost and the Darkness	tt0116409	Bruce Stambler	Bruce Stambler	nm0821801	True
@@ -8356,11 +8356,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 70	1997	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0048637	Sweethearts?	tt0141868	Birger Larsen, Thomas Lydholm	Birger Larsen, Thomas Lydholm	nm0488715,nm0527980
 70	1997	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0048634	Visas and Virtue	tt0141963	Chris Tashima, Chris Donahue	Chris Tashima, Chris Donahue	nm0850875,nm0231934	True
 70	1997	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0048638	Wolfgang	tt0141995	Kim Magnusson, Anders Thomas Jensen	Kim Magnusson, Anders Thomas Jensen	nm0536385,nm0421314
-70	1997	Production	SOUND	SOUND	an0048596	Air Force One	tt0118571	Paul Massey, Rick Kline, D. M. Hemphill, Keith A. Wester	Paul Massey, Rick Kline, D. M. Hemphill, Keith A. Wester	nm0557338,nm0459662,nm0376153,nm0199492
-70	1997	Production	SOUND	SOUND	an0048597	Con Air	tt0118880	Kevin O'Connell, Greg P. Russell, Arthur Rochester	Kevin O'Connell, Greg P. Russell, Arthur Rochester	nm0640114,nm0751169,nm0734053
-70	1997	Production	SOUND	SOUND	an0048598	Contact	tt0118884	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	nm0858378,nm0426348,nm0762304,nm0438202
-70	1997	Production	SOUND	SOUND	an0048599	L.A. Confidential	tt0119488	Andy Nelson, Anna Behlmer, Kirk Francis	Andy Nelson, Anna Behlmer, Kirk Francis	nm0625144,nm0066933,nm0290220
-70	1997	Production	SOUND	SOUND	an0048595	Titanic	tt0120338	Gary Rydstrom, Tom Johnson, Gary Summers, Mark Ulano	Gary Rydstrom, Tom Johnson, Gary Summers, Mark Ulano	nm0003977,nm0426348,nm0838707,nm0880360	True
+70	1997	Production	SOUND MIXING	SOUND	an0048596	Air Force One	tt0118571	Paul Massey, Rick Kline, D. M. Hemphill, Keith A. Wester	Paul Massey, Rick Kline, D. M. Hemphill, Keith A. Wester	nm0557338,nm0459662,nm0376153,nm0199492
+70	1997	Production	SOUND MIXING	SOUND	an0048597	Con Air	tt0118880	Kevin O'Connell, Greg P. Russell, Arthur Rochester	Kevin O'Connell, Greg P. Russell, Arthur Rochester	nm0640114,nm0751169,nm0734053
+70	1997	Production	SOUND MIXING	SOUND	an0048598	Contact	tt0118884	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	nm0858378,nm0426348,nm0762304,nm0438202
+70	1997	Production	SOUND MIXING	SOUND	an0048599	L.A. Confidential	tt0119488	Andy Nelson, Anna Behlmer, Kirk Francis	Andy Nelson, Anna Behlmer, Kirk Francis	nm0625144,nm0066933,nm0290220
+70	1997	Production	SOUND MIXING	SOUND	an0048595	Titanic	tt0120338	Gary Rydstrom, Tom Johnson, Gary Summers, Mark Ulano	Gary Rydstrom, Tom Johnson, Gary Summers, Mark Ulano	nm0003977,nm0426348,nm0838707,nm0880360	True
 70	1997	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0048606	Face/Off	tt0119094	Mark P. Stoeckinger, Per Hallberg	Mark P. Stoeckinger, Per Hallberg	nm0831057,nm0356319
 70	1997	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0048607	The Fifth Element	tt0119116	Mark Mangini	Mark Mangini	nm0005625
 70	1997	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0048605	Titanic	tt0120338	Tom Bellfort, Christopher Boyes	Tom Bellfort, Christopher Boyes	nm0068938,nm0102110	True
@@ -8491,11 +8491,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 71	1998	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0057270	Holiday Romance	tt0188667	Alexander Jovy, JJ Keith	Alexander Jovy, JJ Keith	nm0003473,nm0445249
 71	1998	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0057271	La Carte Postale (The Postcard)	tt0188485	Vivian Goffette	Vivian Goffette	nm0324600
 71	1998	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0057272	Victor	tt0189186	Simon Sandquist, Joel Bergvall	Simon Sandquist, Joel Bergvall	nm0762217,nm0075150
-71	1998	Production	SOUND	SOUND	an0057230	Armageddon	tt0120591	Kevin O'Connell, Greg P. Russell, Keith A. Wester	Kevin O'Connell, Greg P. Russell, Keith A. Wester	nm0640114,nm0751169,nm0199492
-71	1998	Production	SOUND	SOUND	an0057231	The Mask of Zorro	tt0120746	Kevin O'Connell, Greg P. Russell, Pud Cusack	Kevin O'Connell, Greg P. Russell, Pud Cusack	nm0640114,nm0751169,nm0193650
-71	1998	Production	SOUND	SOUND	an0057229	Saving Private Ryan	tt0120815	Gary Rydstrom, Gary Summers, Andy Nelson, Ronald Judkins	Gary Rydstrom, Gary Summers, Andy Nelson, Ronald Judkins	nm0003977,nm0838707,nm0625144,nm0431954	True
-71	1998	Production	SOUND	SOUND	an0057232	Shakespeare in Love	tt0138097	Robin O'Donoghue, Dominic Lester, Peter Glossop	Robin O'Donoghue, Dominic Lester, Peter Glossop	nm0640877,nm0504438,nm0323049
-71	1998	Production	SOUND	SOUND	an0057233	The Thin Red Line	tt0120863	Andy Nelson, Anna Behlmer, Paul Brincat	Andy Nelson, Anna Behlmer, Paul Brincat	nm0625144,nm0066933,nm0109444
+71	1998	Production	SOUND MIXING	SOUND	an0057230	Armageddon	tt0120591	Kevin O'Connell, Greg P. Russell, Keith A. Wester	Kevin O'Connell, Greg P. Russell, Keith A. Wester	nm0640114,nm0751169,nm0199492
+71	1998	Production	SOUND MIXING	SOUND	an0057231	The Mask of Zorro	tt0120746	Kevin O'Connell, Greg P. Russell, Pud Cusack	Kevin O'Connell, Greg P. Russell, Pud Cusack	nm0640114,nm0751169,nm0193650
+71	1998	Production	SOUND MIXING	SOUND	an0057229	Saving Private Ryan	tt0120815	Gary Rydstrom, Gary Summers, Andy Nelson, Ronald Judkins	Gary Rydstrom, Gary Summers, Andy Nelson, Ronald Judkins	nm0003977,nm0838707,nm0625144,nm0431954	True
+71	1998	Production	SOUND MIXING	SOUND	an0057232	Shakespeare in Love	tt0138097	Robin O'Donoghue, Dominic Lester, Peter Glossop	Robin O'Donoghue, Dominic Lester, Peter Glossop	nm0640877,nm0504438,nm0323049
+71	1998	Production	SOUND MIXING	SOUND	an0057233	The Thin Red Line	tt0120863	Andy Nelson, Anna Behlmer, Paul Brincat	Andy Nelson, Anna Behlmer, Paul Brincat	nm0625144,nm0066933,nm0109444
 71	1998	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0057240	Armageddon	tt0120591	George Watters II	George Watters II	nm0915036
 71	1998	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0057241	The Mask of Zorro	tt0120746	David McMoyler	David McMoyler	nm0573393
 71	1998	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0057239	Saving Private Ryan	tt0120815	Gary Rydstrom, Richard Hymns	Gary Rydstrom, Richard Hymns	nm0003977,nm0405232	True
@@ -8637,11 +8637,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 72	1999	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055260	Kleingeld (Small Change)	tt0200780	Marc-Andreas Bochert, Gabriele Lins	Marc-Andreas Bochert, Gabriele Lins	nm0090596,nm0513115
 72	1999	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055261	Major and Minor Miracles	tt0239583	Marcus Olsson	Marcus Olsson	nm0648103
 72	1999	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055257	My Mother Dreams the Satan's Disciples in New York	tt0177023	Barbara Schock, Tammy Tiehel	Barbara Schock, Tammy Tiehel	nm0774294,nm0862843	True
-72	1999	Production	SOUND	SOUND	an0055234	The Green Mile	tt0120689	Robert J. Litt, Elliot Tyson, Michael Herbick, Willie D. Burton	Robert J. Litt, Elliot Tyson, Michael Herbick, Willie D. Burton	nm0514448,nm0006525,nm0378655,nm0123770
-72	1999	Production	SOUND	SOUND	an0055235	The Insider	tt0140352	Andy Nelson, Doug Hemphill, Lee Orloff	Andy Nelson, Doug Hemphill, Lee Orloff	nm0625144,nm0376153,nm0650090
-72	1999	Production	SOUND	SOUND	an0055233	The Matrix	tt0133093	John Reitz, Gregg Rudloff, David Campbell, David Lee	John Reitz, Gregg Rudloff, David Campbell, David Lee	nm0718676,nm0748832,nm0132372,nm1325883	True
-72	1999	Production	SOUND	SOUND	an0055236	The Mummy	tt0120616	Leslie Shatz, Chris Carpenter, Rick Kline, Chris Munro	Leslie Shatz, Chris Carpenter, Rick Kline, Chris Munro	nm0789458,nm0139303,nm0459662,nm0613101
-72	1999	Production	SOUND	SOUND	an0055237	Star Wars Episode I: The Phantom Menace	tt0120915	Gary Rydstrom, Tom Johnson, Shawn Murphy, John Midgley	Gary Rydstrom, Tom Johnson, Shawn Murphy, John Midgley	nm0003977,nm0426348,nm0004156,nm0585611
+72	1999	Production	SOUND MIXING	SOUND	an0055234	The Green Mile	tt0120689	Robert J. Litt, Elliot Tyson, Michael Herbick, Willie D. Burton	Robert J. Litt, Elliot Tyson, Michael Herbick, Willie D. Burton	nm0514448,nm0006525,nm0378655,nm0123770
+72	1999	Production	SOUND MIXING	SOUND	an0055235	The Insider	tt0140352	Andy Nelson, Doug Hemphill, Lee Orloff	Andy Nelson, Doug Hemphill, Lee Orloff	nm0625144,nm0376153,nm0650090
+72	1999	Production	SOUND MIXING	SOUND	an0055233	The Matrix	tt0133093	John Reitz, Gregg Rudloff, David Campbell, David Lee	John Reitz, Gregg Rudloff, David Campbell, David Lee	nm0718676,nm0748832,nm0132372,nm1325883	True
+72	1999	Production	SOUND MIXING	SOUND	an0055236	The Mummy	tt0120616	Leslie Shatz, Chris Carpenter, Rick Kline, Chris Munro	Leslie Shatz, Chris Carpenter, Rick Kline, Chris Munro	nm0789458,nm0139303,nm0459662,nm0613101
+72	1999	Production	SOUND MIXING	SOUND	an0055237	Star Wars Episode I: The Phantom Menace	tt0120915	Gary Rydstrom, Tom Johnson, Shawn Murphy, John Midgley	Gary Rydstrom, Tom Johnson, Shawn Murphy, John Midgley	nm0003977,nm0426348,nm0004156,nm0585611
 72	1999	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0055239	Fight Club	tt0137523	Ren Klyce, Richard Hymns	Ren Klyce, Richard Hymns	nm0460274,nm0405232
 72	1999	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0055238	The Matrix	tt0133093	Dane A. Davis	Dane A. Davis	nm0204424	True
 72	1999	Production	SOUND EDITING	SOUND EFFECTS EDITING	an0055240	Star Wars Episode I: The Phantom Menace	tt0120915	Ben Burtt, Tom Bellfort	Ben Burtt, Tom Bellfort	nm0123785,nm0068938
@@ -8762,11 +8762,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 73	2000	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050884	Quiero Ser (I want to be...)	tt0216131	Florian Gallenberger	Florian Gallenberger	nm0302780	True
 73	2000	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050887	Seraglio	tt0262758	Gail Lerner, Colin Campbell	Gail Lerner, Colin Campbell	nm0503611,nm0132330
 73	2000	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0050888	A Soccer Story (Uma Historia de Futebol)	tt0207112	Paulo Machline	Paulo Machline	nm0003884
-73	2000	Production	SOUND	SOUND	an0050862	Cast Away	tt0162222	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	nm0858378,nm0426348,nm0762304,nm0438202
-73	2000	Production	SOUND	SOUND	an0050861	Gladiator	tt0172495	Scott Millan, Bob Beemer, Ken Weston	Scott Millan, Bob Beemer, Ken Weston	nm0586793,nm0066446,nm0922984	True
-73	2000	Production	SOUND	SOUND	an0050863	The Patriot	tt0187393	Kevin O'Connell, Greg P. Russell, Lee Orloff	Kevin O'Connell, Greg P. Russell, Lee Orloff	nm0640114,nm0751169,nm0650090
-73	2000	Production	SOUND	SOUND	an0050864	The Perfect Storm	tt0177971	John Reitz, Gregg Rudloff, David Campbell, Keith A. Wester	John Reitz, Gregg Rudloff, David Campbell, Keith A. Wester	nm0718676,nm0748832,nm0132372,nm0199492
-73	2000	Production	SOUND	SOUND	an0050865	U-571	tt0141926	Steve Maslow, Gregg Landaker, Rick Kline, Ivan Sharrock	Steve Maslow, Gregg Landaker, Rick Kline, Ivan Sharrock	nm0556541,nm0484414,nm0459662,nm0789331
+73	2000	Production	SOUND MIXING	SOUND	an0050862	Cast Away	tt0162222	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	Randy Thom, Tom Johnson, Dennis Sands, William B. Kaplan	nm0858378,nm0426348,nm0762304,nm0438202
+73	2000	Production	SOUND MIXING	SOUND	an0050861	Gladiator	tt0172495	Scott Millan, Bob Beemer, Ken Weston	Scott Millan, Bob Beemer, Ken Weston	nm0586793,nm0066446,nm0922984	True
+73	2000	Production	SOUND MIXING	SOUND	an0050863	The Patriot	tt0187393	Kevin O'Connell, Greg P. Russell, Lee Orloff	Kevin O'Connell, Greg P. Russell, Lee Orloff	nm0640114,nm0751169,nm0650090
+73	2000	Production	SOUND MIXING	SOUND	an0050864	The Perfect Storm	tt0177971	John Reitz, Gregg Rudloff, David Campbell, Keith A. Wester	John Reitz, Gregg Rudloff, David Campbell, Keith A. Wester	nm0718676,nm0748832,nm0132372,nm0199492
+73	2000	Production	SOUND MIXING	SOUND	an0050865	U-571	tt0141926	Steve Maslow, Gregg Landaker, Rick Kline, Ivan Sharrock	Steve Maslow, Gregg Landaker, Rick Kline, Ivan Sharrock	nm0556541,nm0484414,nm0459662,nm0789331
 73	2000	Production	SOUND EDITING	SOUND EDITING	an0050867	Space Cowboys	tt0186566	Alan Robert Murray, Bub Asman	Alan Robert Murray, Bub Asman	nm0614812,nm0039544
 73	2000	Production	SOUND EDITING	SOUND EDITING	an0050866	U-571	tt0141926	Jon Johnson	Jon Johnson	nm0425416	True
 73	2000	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0050868	Gladiator	tt0172495	John Nelson, Neil Corbould, Tim Burke, Rob Harvey	John Nelson, Neil Corbould, Tim Burke, Rob Harvey	nm0625471,nm0179273,nm0121888,nm0367690	True
@@ -8894,11 +8894,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 74	2001	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055478	Gregor's Greatest Invention	tt0304107	Johannes Kiefer	Johannes Kiefer	nm0452374
 74	2001	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055479	A Man Thing (Meska Sprawa)	tt0304394	Slawomir Fabicki, Bogumil Godfrejow	Slawomir Fabicki, Bogumil Godfrejow	nm0264614,nm0323950
 74	2001	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055480	Speed for Thespians	tt0269899	Kalman Apple, Shameela Bakhsh	Kalman Apple, Shameela Bakhsh	nm0032315,nm0049075
-74	2001	Production	SOUND	SOUND	an0055451	Amélie	tt0211915	Vincent Arnardi, Guillaume Leriche, Jean Umansky	Vincent Arnardi, Guillaume Leriche, Jean Umansky	nm0003399,nm1054914,nm0880796
-74	2001	Production	SOUND	SOUND	an0055450	Black Hawk Down	tt0265086	Michael Minkler, Myron Nettinga, Chris Munro	Michael Minkler, Myron Nettinga, Chris Munro	nm0591444,nm0002383,nm0613101	True
-74	2001	Production	SOUND	SOUND	an0055452	The Lord of the Rings: The Fellowship of the Ring	tt0120737	Christopher Boyes, Michael Semanick, Gethin Creagh, Hammond Peek	Christopher Boyes, Michael Semanick, Gethin Creagh, Hammond Peek	nm0102110,nm0783713,nm0187098,nm0003827
-74	2001	Production	SOUND	SOUND	an0055453	Moulin Rouge	tt0203009	Andy Nelson, Anna Behlmer, Roger Savage, Guntis Sics	Andy Nelson, Anna Behlmer, Roger Savage, Guntis Sics	nm0625144,nm0066933,nm0767373,nm0796456
-74	2001	Production	SOUND	SOUND	an0055454	Pearl Harbor	tt0213149	Kevin O'Connell, Greg P. Russell, Peter J. Devlin	Kevin O'Connell, Greg P. Russell, Peter J. Devlin	nm0640114,nm0751169,nm0222818
+74	2001	Production	SOUND MIXING	SOUND	an0055451	Amélie	tt0211915	Vincent Arnardi, Guillaume Leriche, Jean Umansky	Vincent Arnardi, Guillaume Leriche, Jean Umansky	nm0003399,nm1054914,nm0880796
+74	2001	Production	SOUND MIXING	SOUND	an0055450	Black Hawk Down	tt0265086	Michael Minkler, Myron Nettinga, Chris Munro	Michael Minkler, Myron Nettinga, Chris Munro	nm0591444,nm0002383,nm0613101	True
+74	2001	Production	SOUND MIXING	SOUND	an0055452	The Lord of the Rings: The Fellowship of the Ring	tt0120737	Christopher Boyes, Michael Semanick, Gethin Creagh, Hammond Peek	Christopher Boyes, Michael Semanick, Gethin Creagh, Hammond Peek	nm0102110,nm0783713,nm0187098,nm0003827
+74	2001	Production	SOUND MIXING	SOUND	an0055453	Moulin Rouge	tt0203009	Andy Nelson, Anna Behlmer, Roger Savage, Guntis Sics	Andy Nelson, Anna Behlmer, Roger Savage, Guntis Sics	nm0625144,nm0066933,nm0767373,nm0796456
+74	2001	Production	SOUND MIXING	SOUND	an0055454	Pearl Harbor	tt0213149	Kevin O'Connell, Greg P. Russell, Peter J. Devlin	Kevin O'Connell, Greg P. Russell, Peter J. Devlin	nm0640114,nm0751169,nm0222818
 74	2001	Production	SOUND EDITING	SOUND EDITING	an0055456	Monsters, Inc.	tt0198781	Gary Rydstrom, Michael Silvers	Gary Rydstrom, Michael Silvers	nm0003977,nm0799011
 74	2001	Production	SOUND EDITING	SOUND EDITING	an0055455	Pearl Harbor	tt0213149	George Watters II, Christopher Boyes	George Watters II, Christopher Boyes	nm0915036,nm0102110	True
 74	2001	Production	VISUAL EFFECTS	VISUAL EFFECTS	an0055458	A.I. Artificial Intelligence	tt0212720	Dennis Muren, Scott Farrar, Stan Winston, Michael Lantieri	Dennis Muren, Scott Farrar, Stan Winston, Michael Lantieri	nm0613830,nm0268141,nm0935644,nm0487177
@@ -9033,11 +9033,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 75	2002	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055012	Inja (Dog)	tt0303350	Steven Pasvolsky, Joe Weatherstone	Steven Pasvolsky, Joe Weatherstone	nm1099262,nm0915787
 75	2002	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055014	Johnny Flynton	tt0329245	Lexi Alexander, Alexander Buono	Lexi Alexander, Alexander Buono	nm0591994,nm0120645
 75	2002	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an0055010	This Charming Man (Der Er En Yndig Mand)	tt0340071	Martin Strange-Hansen, Mie Andreasen	Martin Strange-Hansen, Mie Andreasen	nm1015687,nm1212399	True
-75	2002	Production	SOUND	SOUND	an0054973	Chicago	tt0299658	Michael Minkler, Dominick Tavella, David Lee	Michael Minkler, Dominick Tavella, David Lee	nm0591444,nm0003838,nm0497112	True
-75	2002	Production	SOUND	SOUND	an0054974	Gangs of New York	tt0217505	Tom Fleischman, Eugene Gearty, Ivan Sharrock	Tom Fleischman, Eugene Gearty, Ivan Sharrock	nm0281530,nm0311267,nm0789331
-75	2002	Production	SOUND	SOUND	an0054975	The Lord of the Rings: The Two Towers	tt0167261	Christopher Boyes, Michael Semanick, Michael Hedges, Hammond Peek	Christopher Boyes, Michael Semanick, Michael Hedges, Hammond Peek	nm0102110,nm0783713,nm0373276,nm0003827
-75	2002	Production	SOUND	SOUND	an0054976	Road to Perdition	tt0257044	Scott Millan, Bob Beemer, John Patrick Pritchett	Scott Millan, Bob Beemer, John Patrick Pritchett	nm0586793,nm0066446,nm0698099
-75	2002	Production	SOUND	SOUND	an0054977	Spider-Man	tt0145487	Kevin O'Connell, Greg P. Russell, Ed Novick	Kevin O'Connell, Greg P. Russell, Ed Novick	nm0640114,nm0751169,nm0637085
+75	2002	Production	SOUND MIXING	SOUND	an0054973	Chicago	tt0299658	Michael Minkler, Dominick Tavella, David Lee	Michael Minkler, Dominick Tavella, David Lee	nm0591444,nm0003838,nm0497112	True
+75	2002	Production	SOUND MIXING	SOUND	an0054974	Gangs of New York	tt0217505	Tom Fleischman, Eugene Gearty, Ivan Sharrock	Tom Fleischman, Eugene Gearty, Ivan Sharrock	nm0281530,nm0311267,nm0789331
+75	2002	Production	SOUND MIXING	SOUND	an0054975	The Lord of the Rings: The Two Towers	tt0167261	Christopher Boyes, Michael Semanick, Michael Hedges, Hammond Peek	Christopher Boyes, Michael Semanick, Michael Hedges, Hammond Peek	nm0102110,nm0783713,nm0373276,nm0003827
+75	2002	Production	SOUND MIXING	SOUND	an0054976	Road to Perdition	tt0257044	Scott Millan, Bob Beemer, John Patrick Pritchett	Scott Millan, Bob Beemer, John Patrick Pritchett	nm0586793,nm0066446,nm0698099
+75	2002	Production	SOUND MIXING	SOUND	an0054977	Spider-Man	tt0145487	Kevin O'Connell, Greg P. Russell, Ed Novick	Kevin O'Connell, Greg P. Russell, Ed Novick	nm0640114,nm0751169,nm0637085
 75	2002	Production	SOUND EDITING	SOUND EDITING	an0054978	The Lord of the Rings: The Two Towers	tt0167261	Ethan Van der Ryn, Michael Hopkins	Ethan Van der Ryn, Michael Hopkins	nm0886399,nm0394243	True
 75	2002	Production	SOUND EDITING	SOUND EDITING	an0054979	Minority Report	tt0181689	Richard Hymns, Gary Rydstrom	Richard Hymns, Gary Rydstrom	nm0405232,nm0003977
 75	2002	Production	SOUND EDITING	SOUND EDITING	an0054980	Road to Perdition	tt0257044	Scott A. Hecker	Scott A. Hecker	nm0373046
@@ -10313,11 +10313,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 85	2012	Title	BEST PICTURE	BEST PICTURE	an0428406	Lincoln	tt0443272	Steven Spielberg and Kathleen Kennedy, Producers	Steven Spielberg, Kathleen Kennedy	nm0000229,nm0005086
 85	2012	Title	BEST PICTURE	BEST PICTURE	an0428407	Silver Linings Playbook	tt1045658	Donna Gigliotti, Bruce Cohen and Jonathan Gordon, Producers	Donna Gigliotti, Bruce Cohen, Jonathan Gordon	nm0317642,nm0169260,nm0330335
 85	2012	Title	BEST PICTURE	BEST PICTURE	an0428408	Zero Dark Thirty	tt1790885	Mark Boal, Kathryn Bigelow and Megan Ellison, Producers	Mark Boal, Kathryn Bigelow, Megan Ellison	nm1676793,nm0000941,nm2691892
-85	2012	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0428598	Anna Karenina	tt1781769	Production Design: Sarah Greenwood; Set Decoration: Katie Spencer	Sarah Greenwood, Katie Spencer	nm0339391,nm0818005
-85	2012	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0428599	The Hobbit: An Unexpected Journey	tt0903624	Production Design: Dan Hennah; Set Decoration: Ra Vincent and Simon Bright	Dan Hennah, Ra Vincent, Simon Bright	nm0377172,nm1308151,nm0109186
-85	2012	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0428600	Les Misérables	tt1707386	Production Design: Eve Stewart; Set Decoration: Anna Lynch-Robinson	Eve Stewart, Anna Lynch-Robinson	nm0829378,nm0528498
-85	2012	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0428601	Life of Pi	tt0454876	Production Design: David Gropman; Set Decoration: Anna Pinnock	David Gropman, Anna Pinnock	nm0343222,nm0003519
-85	2012	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0428602	Lincoln	tt0443272	Production Design: Rick Carter; Set Decoration: Jim Erickson	Rick Carter, Jim Erickson	nm0141437,nm1075312	True
+85	2012	Production	ART DIRECTION	PRODUCTION DESIGN	an0428598	Anna Karenina	tt1781769	Production Design: Sarah Greenwood; Set Decoration: Katie Spencer	Sarah Greenwood, Katie Spencer	nm0339391,nm0818005
+85	2012	Production	ART DIRECTION	PRODUCTION DESIGN	an0428599	The Hobbit: An Unexpected Journey	tt0903624	Production Design: Dan Hennah; Set Decoration: Ra Vincent and Simon Bright	Dan Hennah, Ra Vincent, Simon Bright	nm0377172,nm1308151,nm0109186
+85	2012	Production	ART DIRECTION	PRODUCTION DESIGN	an0428600	Les Misérables	tt1707386	Production Design: Eve Stewart; Set Decoration: Anna Lynch-Robinson	Eve Stewart, Anna Lynch-Robinson	nm0829378,nm0528498
+85	2012	Production	ART DIRECTION	PRODUCTION DESIGN	an0428601	Life of Pi	tt0454876	Production Design: David Gropman; Set Decoration: Anna Pinnock	David Gropman, Anna Pinnock	nm0343222,nm0003519
+85	2012	Production	ART DIRECTION	PRODUCTION DESIGN	an0428602	Lincoln	tt0443272	Production Design: Rick Carter; Set Decoration: Jim Erickson	Rick Carter, Jim Erickson	nm0141437,nm1075312	True
 85	2012	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0428512	Adam and Dog	tt2162565	Minkyu Lee	Minkyu Lee	nm3767356
 85	2012	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0428513	Fresh Guacamole	tt2309977	PES	PES	nm1396934
 85	2012	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0428514	Head over Heels	tt2391009	Timothy Reckart and Fodhla Cronin O'Reilly	Timothy Reckart, Fodhla Cronin O'Reilly	nm3302450,nm2154065
@@ -10449,11 +10449,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 86	2013	Title	BEST PICTURE	BEST PICTURE	an0481633	Philomena	tt2431286	Gabrielle Tana, Steve Coogan and Tracey Seaward, Producers	Gabrielle Tana, Steve Coogan, Tracey Seaward	nm0848932,nm0176869,nm0780870
 86	2013	Title	BEST PICTURE	BEST PICTURE	an0481635	12 Years a Slave	tt2024544	Brad Pitt, Dede Gardner, Jeremy Kleiner, Steve McQueen and Anthony Katagas, Producers	Brad Pitt, Dede Gardner, Jeremy Kleiner, Steve McQueen, Anthony Katagas	nm0000093,nm0306890,nm1250070,nm2588606,nm0441097	True
 86	2013	Title	BEST PICTURE	BEST PICTURE	an0482880	The Wolf of Wall Street	tt0993846	Martin Scorsese, Leonardo DiCaprio, Joey McFarland and Emma Tillinger Koskoff, Producers	Martin Scorsese, Leonardo DiCaprio, Joey McFarland, Emma Tillinger Koskoff	nm0000217,nm0000138,nm2110175,nm0863374
-86	2013	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0481858	American Hustle	tt1800241	Production Design: Judy Becker; Set Decoration: Heather Loeffler	Judy Becker, Heather Loeffler	nm0065473,nm1346736
-86	2013	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0481859	Gravity	tt1454468	Production Design: Andy Nicholson; Set Decoration: Rosie Goodwin and Joanne Woollard	Andy Nicholson, Rosie Goodwin, Joanne Woollard	nm0629772,nm2532784,nm0941219
-86	2013	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0481860	The Great Gatsby	tt1343092	Production Design: Catherine Martin; Set Decoration: Beverley Dunn	Catherine Martin, Beverley Dunn	nm0552039,nm1427646	True
-86	2013	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0481861	Her	tt1798709	Production Design: K.K. Barrett; Set Decoration: Gene Serdena	K.K. Barrett, Gene Serdena	nm0057187,nm0784922
-86	2013	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0481862	12 Years a Slave	tt2024544	Production Design: Adam Stockhausen; Set Decoration: Alice Baker	Adam Stockhausen, Alice Baker	nm1360914,nm0048212
+86	2013	Production	ART DIRECTION	PRODUCTION DESIGN	an0481858	American Hustle	tt1800241	Production Design: Judy Becker; Set Decoration: Heather Loeffler	Judy Becker, Heather Loeffler	nm0065473,nm1346736
+86	2013	Production	ART DIRECTION	PRODUCTION DESIGN	an0481859	Gravity	tt1454468	Production Design: Andy Nicholson; Set Decoration: Rosie Goodwin and Joanne Woollard	Andy Nicholson, Rosie Goodwin, Joanne Woollard	nm0629772,nm2532784,nm0941219
+86	2013	Production	ART DIRECTION	PRODUCTION DESIGN	an0481860	The Great Gatsby	tt1343092	Production Design: Catherine Martin; Set Decoration: Beverley Dunn	Catherine Martin, Beverley Dunn	nm0552039,nm1427646	True
+86	2013	Production	ART DIRECTION	PRODUCTION DESIGN	an0481861	Her	tt1798709	Production Design: K.K. Barrett; Set Decoration: Gene Serdena	K.K. Barrett, Gene Serdena	nm0057187,nm0784922
+86	2013	Production	ART DIRECTION	PRODUCTION DESIGN	an0481862	12 Years a Slave	tt2024544	Production Design: Adam Stockhausen; Set Decoration: Alice Baker	Adam Stockhausen, Alice Baker	nm1360914,nm0048212
 86	2013	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0481863	Feral	tt2499022	Daniel Sousa and Dan Golden	Daniel Sousa, Dan Golden	nm1009789,nm3196711
 86	2013	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0481864	Get a Horse!	tt2980764	Lauren MacMullan and Dorothy McKim	Lauren MacMullan, Dorothy McKim	nm0534041,nm1545668
 86	2013	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0481865	Mr. Hublot	tt3043542	Laurent Witz and Alexandre Espigares	Laurent Witz, Alexandre Espigares	nm5793837,nm3115348	True
@@ -10595,11 +10595,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 87	2014	Title	BEST PICTURE	BEST PICTURE	an0606462	Selma	tt1020072	Christian Colson, Oprah Winfrey, Dede Gardner and Jeremy Kleiner, Producers	Christian Colson, Oprah Winfrey, Dede Gardner, Jeremy Kleiner	nm1384503,nm0001856,nm0306890,nm1250070
 87	2014	Title	BEST PICTURE	BEST PICTURE	an0606463	The Theory of Everything	tt2980516	Tim Bevan, Eric Fellner, Lisa Bruce and Anthony McCarten, Producers	Tim Bevan, Eric Fellner, Lisa Bruce, Anthony McCarten	nm0079677,nm0271479,nm0115537,nm0565026
 87	2014	Title	BEST PICTURE	BEST PICTURE	an0606464	Whiplash	tt2582802	Jason Blum, Helen Estabrook and David Lancaster, Producers	Jason Blum, Helen Estabrook, David Lancaster	nm0089658,nm2615685,nm0484123
-87	2014	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0616882	The Grand Budapest Hotel	tt2278388	Production Design: Adam Stockhausen; Set Decoration: Anna Pinnock	Adam Stockhausen, Anna Pinnock	nm1360914,nm0003519	True
-87	2014	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0616883	The Imitation Game	tt2084970	Production Design: Maria Djurkovic; Set Decoration: Tatiana Macdonald	Maria Djurkovic, Tatiana Macdonald	nm0229319,nm0526248
-87	2014	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0616884	Interstellar	tt0816692	Production Design: Nathan Crowley; Set Decoration: Gary Fettis	Nathan Crowley, Gary Fettis	nm0189769,nm0275361
-87	2014	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0616885	Into the Woods	tt2180411	Production Design: Dennis Gassner; Set Decoration: Anna Pinnock	Dennis Gassner, Anna Pinnock	nm0309357,nm0003519
-87	2014	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0616886	Mr. Turner	tt2473794	Production Design: Suzie Davies; Set Decoration: Charlotte Watts	Suzie Davies, Charlotte Watts	nm0203990,nm0915117
+87	2014	Production	ART DIRECTION	PRODUCTION DESIGN	an0616882	The Grand Budapest Hotel	tt2278388	Production Design: Adam Stockhausen; Set Decoration: Anna Pinnock	Adam Stockhausen, Anna Pinnock	nm1360914,nm0003519	True
+87	2014	Production	ART DIRECTION	PRODUCTION DESIGN	an0616883	The Imitation Game	tt2084970	Production Design: Maria Djurkovic; Set Decoration: Tatiana Macdonald	Maria Djurkovic, Tatiana Macdonald	nm0229319,nm0526248
+87	2014	Production	ART DIRECTION	PRODUCTION DESIGN	an0616884	Interstellar	tt0816692	Production Design: Nathan Crowley; Set Decoration: Gary Fettis	Nathan Crowley, Gary Fettis	nm0189769,nm0275361
+87	2014	Production	ART DIRECTION	PRODUCTION DESIGN	an0616885	Into the Woods	tt2180411	Production Design: Dennis Gassner; Set Decoration: Anna Pinnock	Dennis Gassner, Anna Pinnock	nm0309357,nm0003519
+87	2014	Production	ART DIRECTION	PRODUCTION DESIGN	an0616886	Mr. Turner	tt2473794	Production Design: Suzie Davies; Set Decoration: Charlotte Watts	Suzie Davies, Charlotte Watts	nm0203990,nm0915117
 87	2014	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0611292	The Bigger Picture	tt3610188	Daisy Jacobs and Christopher Hees	Daisy Jacobs, Christopher Hees	nm4441366,nm6372097
 87	2014	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0611293	The Dam Keeper	tt3326262	Robert Kondo and Dice Tsutsumi	Robert Kondo, Dice Tsutsumi	nm2937142,nm1156606
 87	2014	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0611294	Feast	tt3689498	Patrick Osborne and Kristina Reed	Patrick Osborne, Kristina Reed	nm2444148,nm0715534	True
@@ -10742,11 +10742,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 88	2015	Title	BEST PICTURE	BEST PICTURE	an0704464	The Revenant	tt1663202	Arnon Milchan, Steve Golin, Alejandro G. Iñárritu, Mary Parent and Keith Redmon, Producers	Arnon Milchan, Steve Golin, Alejandro G. Iñárritu, Mary Parent, Keith Redmon	nm0586969,nm0326512,nm0327944,nm0661289,nm2166024
 88	2015	Title	BEST PICTURE	BEST PICTURE	an0704465	Room	tt3170832	Ed Guiney, Producer	Ed Guiney	nm0347384
 88	2015	Title	BEST PICTURE	BEST PICTURE	an0704463	Spotlight	tt1895587	Michael Sugar, Steve Golin, Nicole Rocklin and Blye Pagon Faust, Producers	Michael Sugar, Steve Golin, Nicole Rocklin, Blye Pagon Faust	nm0837386,nm0326512,nm2140746,nm1421308	True
-88	2015	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0711235	Bridge of Spies	tt3682448	Production Design: Adam Stockhausen; Set Decoration: Rena DeAngelo and Bernhard Henrich	Adam Stockhausen, Rena DeAngelo, Bernhard Henrich	nm1360914,nm0213076,nm0377520
-88	2015	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0711236	The Danish Girl	tt0810819	Production Design: Eve Stewart; Set Decoration: Michael Standish	Eve Stewart, Michael Standish	nm0829378,nm0822086
-88	2015	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0711237	Mad Max: Fury Road	tt1392190	Production Design: Colin Gibson; Set Decoration: Lisa Thompson	Colin Gibson, Lisa Thompson	nm0316904,nm0860424	True
-88	2015	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0711238	The Martian	tt3659388	Production Design: Arthur Max; Set Decoration: Celia Bobak	Arthur Max, Celia Bobak	nm0561480,nm0090278
-88	2015	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0711239	The Revenant	tt1663202	Production Design: Jack Fisk; Set Decoration: Hamish Purdy	Jack Fisk, Hamish Purdy	nm0279926,nm0700827
+88	2015	Production	ART DIRECTION	PRODUCTION DESIGN	an0711235	Bridge of Spies	tt3682448	Production Design: Adam Stockhausen; Set Decoration: Rena DeAngelo and Bernhard Henrich	Adam Stockhausen, Rena DeAngelo, Bernhard Henrich	nm1360914,nm0213076,nm0377520
+88	2015	Production	ART DIRECTION	PRODUCTION DESIGN	an0711236	The Danish Girl	tt0810819	Production Design: Eve Stewart; Set Decoration: Michael Standish	Eve Stewart, Michael Standish	nm0829378,nm0822086
+88	2015	Production	ART DIRECTION	PRODUCTION DESIGN	an0711237	Mad Max: Fury Road	tt1392190	Production Design: Colin Gibson; Set Decoration: Lisa Thompson	Colin Gibson, Lisa Thompson	nm0316904,nm0860424	True
+88	2015	Production	ART DIRECTION	PRODUCTION DESIGN	an0711238	The Martian	tt3659388	Production Design: Arthur Max; Set Decoration: Celia Bobak	Arthur Max, Celia Bobak	nm0561480,nm0090278
+88	2015	Production	ART DIRECTION	PRODUCTION DESIGN	an0711239	The Revenant	tt1663202	Production Design: Jack Fisk; Set Decoration: Hamish Purdy	Jack Fisk, Hamish Purdy	nm0279926,nm0700827
 88	2015	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0704574	Bear Story	tt3829254	Gabriel Osorio and Pato Escala	Gabriel Osorio, Pato Escala	nm6594925,nm6594926	True
 88	2015	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0704576	Prologue	tt4955294	Richard Williams and Imogen Sutton	Richard Williams, Imogen Sutton	nm0931530,nm1803609
 88	2015	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0704577	Sanjay's Super Team	tt4661600	Sanjay Patel and Nicole Grindle	Sanjay Patel, Nicole Grindle	nm0665396,nm0342430
@@ -10878,11 +10878,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 89	2016	Title	BEST PICTURE	BEST PICTURE	an0808521	Lion	tt3741834	Emile Sherman, Iain Canning and Angie Fielder, Producers	Emile Sherman, Iain Canning, Angie Fielder	nm0792431,nm2096617,nm2652108
 89	2016	Title	BEST PICTURE	BEST PICTURE	an0808522	Manchester by the Sea	tt4034228	Matt Damon, Kimberly Steward, Chris Moore, Lauren Beck and Kevin J. Walsh, Producers	Matt Damon, Kimberly Steward, Chris Moore, Lauren Beck, Kevin J. Walsh	nm0000354,nm6844518,nm0601031,nm4568172,nm1016966
 89	2016	Title	BEST PICTURE	BEST PICTURE	an0808523	Moonlight	tt4975722	Adele Romanski, Dede Gardner and Jeremy Kleiner, Producers	Adele Romanski, Dede Gardner, Jeremy Kleiner	nm1532846,nm0306890,nm1250070	True
-89	2016	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0811478	Arrival	tt2543164	Production Design: Patrice Vermette; Set Decoration: Paul Hotte	Patrice Vermette, Paul Hotte	nm0894411,nm0396257
-89	2016	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0811479	Fantastic Beasts and Where to Find Them	tt3183660	Production Design: Stuart Craig; Set Decoration: Anna Pinnock	Stuart Craig, Anna Pinnock	nm0186023,nm0003519
-89	2016	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0811480	Hail, Caesar!	tt0475290	Production Design: Jess Gonchor; Set Decoration: Nancy Haigh	Jess Gonchor, Nancy Haigh	nm0327211,nm0354101
-89	2016	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0811481	La La Land	tt3783958	Production Design: David Wasco; Set Decoration: Sandy Reynolds-Wasco	David Wasco, Sandy Reynolds-Wasco	nm0913300,nm0722012	True
-89	2016	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0811482	Passengers	tt1355644	Production Design: Guy Hendrix Dyas; Set Decoration: Gene Serdena	Guy Hendrix Dyas, Gene Serdena	nm0245596,nm0784922
+89	2016	Production	ART DIRECTION	PRODUCTION DESIGN	an0811478	Arrival	tt2543164	Production Design: Patrice Vermette; Set Decoration: Paul Hotte	Patrice Vermette, Paul Hotte	nm0894411,nm0396257
+89	2016	Production	ART DIRECTION	PRODUCTION DESIGN	an0811479	Fantastic Beasts and Where to Find Them	tt3183660	Production Design: Stuart Craig; Set Decoration: Anna Pinnock	Stuart Craig, Anna Pinnock	nm0186023,nm0003519
+89	2016	Production	ART DIRECTION	PRODUCTION DESIGN	an0811480	Hail, Caesar!	tt0475290	Production Design: Jess Gonchor; Set Decoration: Nancy Haigh	Jess Gonchor, Nancy Haigh	nm0327211,nm0354101
+89	2016	Production	ART DIRECTION	PRODUCTION DESIGN	an0811481	La La Land	tt3783958	Production Design: David Wasco; Set Decoration: Sandy Reynolds-Wasco	David Wasco, Sandy Reynolds-Wasco	nm0913300,nm0722012	True
+89	2016	Production	ART DIRECTION	PRODUCTION DESIGN	an0811482	Passengers	tt1355644	Production Design: Guy Hendrix Dyas; Set Decoration: Gene Serdena	Guy Hendrix Dyas, Gene Serdena	nm0245596,nm0784922
 89	2016	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0808627	Blind Vaysha	tt5559726	Theodore Ushev	Theodore Ushev	nm1507308
 89	2016	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0808628	Borrowed Time	tt4874696	Andrew Coats and Lou Hamou-Lhadj	Andrew Coats, Lou Hamou-Lhadj	nm2855383,nm3210583
 89	2016	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0808629	Pear Cider and Cigarettes	tt5358978	Robert Valley and Cara Speller	Robert Valley, Cara Speller	nm3230254,nm1230132
@@ -11022,11 +11022,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 90	2017	Title	BEST PICTURE	BEST PICTURE	an0943526	The Post	tt6294822	Amy Pascal, Steven Spielberg and Kristie Macosko Krieger, Producers	Amy Pascal, Steven Spielberg, Kristie Macosko Krieger	nm1166871,nm0000229,nm1069736
 90	2017	Title	BEST PICTURE	BEST PICTURE	an0943528	The Shape of Water	tt5580390	Guillermo del Toro and J. Miles Dale, Producers	Guillermo del Toro, J. Miles Dale	nm0868219,nm0197703	True
 90	2017	Title	BEST PICTURE	BEST PICTURE	an0943527	Three Billboards outside Ebbing, Missouri	tt5027774	Graham Broadbent, Pete Czernin and Martin McDonagh, Producers	Graham Broadbent, Pete Czernin, Martin McDonagh	nm0110357,nm0194446,nm1732981
-90	2017	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0954559	Beauty and the Beast	tt2771200	Production Design: Sarah Greenwood; Set Decoration: Katie Spencer	Sarah Greenwood, Katie Spencer	nm0339391,nm0818005
-90	2017	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0954557	Blade Runner 2049	tt1856101	Production Design: Dennis Gassner; Set Decoration: Alessandra Querzola	Dennis Gassner, Alessandra Querzola	nm0309357,nm0703301
-90	2017	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0954558	Darkest Hour	tt4555426	Production Design: Sarah Greenwood; Set Decoration: Katie Spencer	Sarah Greenwood, Katie Spencer	nm0339391,nm0818005
-90	2017	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0954549	Dunkirk	tt5013056	Production Design: Nathan Crowley; Set Decoration: Gary Fettis	Nathan Crowley, Gary Fettis	nm0189769,nm0275361
-90	2017	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an0954560	The Shape of Water	tt5580390	Production Design: Paul Denham Austerberry; Set Decoration: Shane Vieau and Jeffrey A. Melvin	Paul Denham Austerberry, Shane Vieau, Jeffrey A. Melvin	nm0042306,nm0896580,nm0578518	True
+90	2017	Production	ART DIRECTION	PRODUCTION DESIGN	an0954559	Beauty and the Beast	tt2771200	Production Design: Sarah Greenwood; Set Decoration: Katie Spencer	Sarah Greenwood, Katie Spencer	nm0339391,nm0818005
+90	2017	Production	ART DIRECTION	PRODUCTION DESIGN	an0954557	Blade Runner 2049	tt1856101	Production Design: Dennis Gassner; Set Decoration: Alessandra Querzola	Dennis Gassner, Alessandra Querzola	nm0309357,nm0703301
+90	2017	Production	ART DIRECTION	PRODUCTION DESIGN	an0954558	Darkest Hour	tt4555426	Production Design: Sarah Greenwood; Set Decoration: Katie Spencer	Sarah Greenwood, Katie Spencer	nm0339391,nm0818005
+90	2017	Production	ART DIRECTION	PRODUCTION DESIGN	an0954549	Dunkirk	tt5013056	Production Design: Nathan Crowley; Set Decoration: Gary Fettis	Nathan Crowley, Gary Fettis	nm0189769,nm0275361
+90	2017	Production	ART DIRECTION	PRODUCTION DESIGN	an0954560	The Shape of Water	tt5580390	Production Design: Paul Denham Austerberry; Set Decoration: Shane Vieau and Jeffrey A. Melvin	Paul Denham Austerberry, Shane Vieau, Jeffrey A. Melvin	nm0042306,nm0896580,nm0578518	True
 90	2017	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0908211	Dear Basketball	tt6794476	Glen Keane and Kobe Bryant	Glen Keane, Kobe Bryant	nm0443855,nm1101483	True
 90	2017	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0923067	Garden Party	tt6426140	Victor Caire and Gabriel Grapperon	Victor Caire, Gabriel Grapperon	nm8709842,nm6593003
 90	2017	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an0923072	Lou	tt6267732	Dave Mullins and Dana Murray	Dave Mullins, Dana Murray	nm0612391,nm1733918
@@ -11159,11 +11159,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 91	2018	Title	BEST PICTURE	BEST PICTURE	an1141292	Roma	tt6155172	Gabriela Rodríguez and Alfonso Cuarón, Producers	Gabriela Rodríguez, Alfonso Cuarón	nm2342288,nm0190859
 91	2018	Title	BEST PICTURE	BEST PICTURE	an1141293	A Star Is Born	tt1517451	Bill Gerber, Bradley Cooper and Lynette Howell Taylor, Producers	Bill Gerber, Bradley Cooper, Lynette Howell Taylor	nm0314088,nm0177896,nm1987578
 91	2018	Title	BEST PICTURE	BEST PICTURE	an1141295	Vice	tt6266538	Dede Gardner, Jeremy Kleiner, Adam McKay and Kevin Messick, Producers	Dede Gardner, Jeremy Kleiner, Adam McKay, Kevin Messick	nm0306890,nm1250070,nm0570912,nm0582111
-91	2018	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1141416	Black Panther	tt1825683	Production Design: Hannah Beachler; Set Decoration: Jay Hart	Hannah Beachler, Jay Hart	nm1667545,nm0366345	True
-91	2018	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1139338	The Favourite	tt5083738	Production Design: Fiona Crombie; Set Decoration: Alice Felton	Fiona Crombie, Alice Felton	nm2356249,nm1818912
-91	2018	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1141418	First Man	tt1213641	Production Design: Nathan Crowley; Set Decoration: Kathy Lucas	Nathan Crowley, Kathy Lucas	nm0189769,nm0524205
-91	2018	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1141417	Mary Poppins Returns	tt5028340	Production Design: John Myhre; Set Decoration: Gordon Sim	John Myhre, Gordon Sim	nm0616924,nm0799246
-91	2018	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1141419	Roma	tt6155172	Production Design: Eugenio Caballero; Set Decoration: Bárbara Enríquez	Eugenio Caballero, Bárbara Enríquez	nm0127429,nm1735500
+91	2018	Production	ART DIRECTION	PRODUCTION DESIGN	an1141416	Black Panther	tt1825683	Production Design: Hannah Beachler; Set Decoration: Jay Hart	Hannah Beachler, Jay Hart	nm1667545,nm0366345	True
+91	2018	Production	ART DIRECTION	PRODUCTION DESIGN	an1139338	The Favourite	tt5083738	Production Design: Fiona Crombie; Set Decoration: Alice Felton	Fiona Crombie, Alice Felton	nm2356249,nm1818912
+91	2018	Production	ART DIRECTION	PRODUCTION DESIGN	an1141418	First Man	tt1213641	Production Design: Nathan Crowley; Set Decoration: Kathy Lucas	Nathan Crowley, Kathy Lucas	nm0189769,nm0524205
+91	2018	Production	ART DIRECTION	PRODUCTION DESIGN	an1141417	Mary Poppins Returns	tt5028340	Production Design: John Myhre; Set Decoration: Gordon Sim	John Myhre, Gordon Sim	nm0616924,nm0799246
+91	2018	Production	ART DIRECTION	PRODUCTION DESIGN	an1141419	Roma	tt6155172	Production Design: Eugenio Caballero; Set Decoration: Bárbara Enríquez	Eugenio Caballero, Bárbara Enríquez	nm0127429,nm1735500
 91	2018	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1124711	Animal Behaviour	tt8615478	Alison Snowden and David Fine	Alison Snowden, David Fine	nm0811345,nm0277599
 91	2018	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1124712	Bao	tt8075496	Domee Shi and Becky Neiman-Cobb	Domee Shi, Becky Neiman-Cobb	nm7626019,nm2169250	True
 91	2018	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1124715	Late Afternoon	tt7077824	Louise Bagnall and Nuria González Blanco	Louise Bagnall, Nuria González Blanco	nm5370400,nm4447482
@@ -11297,11 +11297,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 92	2019	Title	BEST PICTURE	BEST PICTURE	an1295014	1917	tt8579674	Sam Mendes, Pippa Harris, Jayne-Ann Tenggren and Callum McDougall, Producers	Sam Mendes, Pippa Harris, Jayne-Ann Tenggren, Callum McDougall	nm0005222,nm0365208,nm0854991,nm0568223
 92	2019	Title	BEST PICTURE	BEST PICTURE	an1295013	Once upon a Time...in Hollywood	tt7131622	David Heyman, Shannon McIntosh and Quentin Tarantino, Producers	David Heyman, Shannon McIntosh, Quentin Tarantino	nm0382268,nm0570690,nm0000233
 92	2019	Title	BEST PICTURE	BEST PICTURE	an1295016	Parasite	tt6751668	Kwak Sin Ae and Bong Joon Ho, Producers	Kwak Sin Ae, Bong Joon Ho	nm10113618,nm0094435	True
-92	2019	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1295959	The Irishman	tt1302006	Production Design: Bob Shaw; Set Decoration: Regina Graves	Bob Shaw, Regina Graves	nm0004052,nm0336340
-92	2019	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1295958	Jojo Rabbit	tt2584384	Production Design: Ra Vincent; Set Decoration: Nora Sopková	Ra Vincent, Nora Sopková	nm1308151,nm4196495
-92	2019	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1295961	1917	tt8579674	Production Design: Dennis Gassner; Set Decoration: Lee Sandales	Dennis Gassner, Lee Sandales	nm0309357,nm0761227
-92	2019	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1295960	Once upon a Time...in Hollywood	tt7131622	Production Design: Barbara Ling; Set Decoration: Nancy Haigh	Barbara Ling, Nancy Haigh	nm0512686,nm0354101	True
-92	2019	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1295962	Parasite	tt6751668	Production Design: Lee Ha Jun; Set Decoration: Cho Won Woo	Lee Ha Jun, Cho Won Woo	nm4342766,nm6657856
+92	2019	Production	ART DIRECTION	PRODUCTION DESIGN	an1295959	The Irishman	tt1302006	Production Design: Bob Shaw; Set Decoration: Regina Graves	Bob Shaw, Regina Graves	nm0004052,nm0336340
+92	2019	Production	ART DIRECTION	PRODUCTION DESIGN	an1295958	Jojo Rabbit	tt2584384	Production Design: Ra Vincent; Set Decoration: Nora Sopková	Ra Vincent, Nora Sopková	nm1308151,nm4196495
+92	2019	Production	ART DIRECTION	PRODUCTION DESIGN	an1295961	1917	tt8579674	Production Design: Dennis Gassner; Set Decoration: Lee Sandales	Dennis Gassner, Lee Sandales	nm0309357,nm0761227
+92	2019	Production	ART DIRECTION	PRODUCTION DESIGN	an1295960	Once upon a Time...in Hollywood	tt7131622	Production Design: Barbara Ling; Set Decoration: Nancy Haigh	Barbara Ling, Nancy Haigh	nm0512686,nm0354101	True
+92	2019	Production	ART DIRECTION	PRODUCTION DESIGN	an1295962	Parasite	tt6751668	Production Design: Lee Ha Jun; Set Decoration: Cho Won Woo	Lee Ha Jun, Cho Won Woo	nm4342766,nm6657856
 92	2019	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1295898	Dcera (Daughter)	tt10923134	Daria Kashcheeva	Daria Kashcheeva	nm9032521
 92	2019	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1295895	Hair Love	tt7129636	Matthew A. Cherry and Karen Rupert Toliver	Matthew A. Cherry, Karen Rupert Toliver	nm1525794,nm2702123	True
 92	2019	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1295896	Kitbull	tt9536832	Rosana Sullivan and Kathryn Hendrickson	Rosana Sullivan, Kathryn Hendrickson	nm3300040,nm4144523
@@ -11441,11 +11441,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 93	2020	Title	BEST PICTURE	BEST PICTURE	an1478479	Promising Young Woman	tt9620292	Ben Browning, Ashley Fox, Emerald Fennell and Josey McNamara, Producers	Ben Browning, Ashley Fox, Emerald Fennell, Josey McNamara	nm1878845,nm4516779,nm2193504,nm3560755
 93	2020	Title	BEST PICTURE	BEST PICTURE	an1478481	Sound of Metal	tt5363618	Bert Hamelinck and Sacha Ben Harroche, Producers	Bert Hamelinck, Sacha Ben Harroche	nm0353012,nm5289961
 93	2020	Title	BEST PICTURE	BEST PICTURE	an1478475	The Trial of the Chicago 7	tt1070874	Marc Platt and Stuart Besser, Producers	Marc Platt, Stuart Besser	nm0686887,nm0078804
-93	2020	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1482205	The Father	tt10272386	Production Design: Peter Francis; Set Decoration: Cathy Featherstone	Peter Francis, Cathy Featherstone	nm0290286,nm1570850
-93	2020	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1480743	Ma Rainey's Black Bottom	tt10514222	Production Design: Mark Ricker; Set Decoration: Karen O'Hara and Diana Stoughton	Mark Ricker, Karen O'Hara, Diana Stoughton	nm0725475,nm0641286,nm0832839
-93	2020	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1480741	Mank	tt10618286	Production Design: Donald Graham Burt; Set Decoration: Jan Pascale	Donald Graham Burt, Jan Pascale	nm0123426,nm0664308	True
-93	2020	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1480742	News of the World	tt6878306	Production Design: David Crank; Set Decoration: Elizabeth Keenan	David Crank, Elizabeth Keenan	nm0186477,nm1404582
-93	2020	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1480744	Tenet	tt6723592	Production Design: Nathan Crowley; Set Decoration: Kathy Lucas	Nathan Crowley, Kathy Lucas	nm0189769,nm0524205
+93	2020	Production	ART DIRECTION	PRODUCTION DESIGN	an1482205	The Father	tt10272386	Production Design: Peter Francis; Set Decoration: Cathy Featherstone	Peter Francis, Cathy Featherstone	nm0290286,nm1570850
+93	2020	Production	ART DIRECTION	PRODUCTION DESIGN	an1480743	Ma Rainey's Black Bottom	tt10514222	Production Design: Mark Ricker; Set Decoration: Karen O'Hara and Diana Stoughton	Mark Ricker, Karen O'Hara, Diana Stoughton	nm0725475,nm0641286,nm0832839
+93	2020	Production	ART DIRECTION	PRODUCTION DESIGN	an1480741	Mank	tt10618286	Production Design: Donald Graham Burt; Set Decoration: Jan Pascale	Donald Graham Burt, Jan Pascale	nm0123426,nm0664308	True
+93	2020	Production	ART DIRECTION	PRODUCTION DESIGN	an1480742	News of the World	tt6878306	Production Design: David Crank; Set Decoration: Elizabeth Keenan	David Crank, Elizabeth Keenan	nm0186477,nm1404582
+93	2020	Production	ART DIRECTION	PRODUCTION DESIGN	an1480744	Tenet	tt6723592	Production Design: Nathan Crowley; Set Decoration: Kathy Lucas	Nathan Crowley, Kathy Lucas	nm0189769,nm0524205
 93	2020	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1480708	Burrow	tt13167288	Madeline Sharafian and Michael Capbarat	Madeline Sharafian, Michael Capbarat	nm6461347,nm6040099
 93	2020	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1482220	Genius Loci	tt11884670	Adrien Mérigeau and Amaury Ovise	Adrien Mérigeau, Amaury Ovise	nm3352576,nm3856500
 93	2020	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1480707	If Anything Happens I Love You	tt11768948	Will McCormack and Michael Govier	Will McCormack, Michael Govier	nm0566489,nm1854728	True
@@ -11456,11 +11456,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 93	2020	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1480687	The Present	tt11474480	Farah Nabulsi and Ossama Bawardi	Farah Nabulsi, Ossama Bawardi	nm9048529,nm3050599
 93	2020	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1480685	Two Distant Strangers	tt13472984	Travon Free and Martin Desmond Roe	Travon Free, Martin Desmond Roe	nm3579257,nm1804553	True
 93	2020	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1482199	White Eye	tt10538710	Tomer Shushan and Shira Hochman	Tomer Shushan, Shira Hochman	nm8781219,nm6735926
-93	2020	Production	SOUND	SOUND	an1480732	Greyhound	tt6048922	Warren Shaw, Michael Minkler, Beau Borders and David Wyman	Warren Shaw, Michael Minkler, Beau Borders, David Wyman	nm0790022,nm0591444,nm0003311,nm1049027
-93	2020	Production	SOUND	SOUND	an1480731	Mank	tt10618286	Ren Klyce, Jeremy Molod, David Parker, Nathan Nance and Drew Kunin	Ren Klyce, Jeremy Molod, David Parker, Nathan Nance, Drew Kunin	nm0460274,nm0597199,nm0662188,nm2315737,nm0475168
-93	2020	Production	SOUND	SOUND	an1480733	News of the World	tt6878306	Oliver Tarney, Mike Prestwood Smith, William Miller and John Pritchett	Oliver Tarney, Mike Prestwood Smith, William Miller, John Pritchett	nm0850549,nm0696523,nm7017920,nm0698099
-93	2020	Production	SOUND	SOUND	an1482217	Soul	tt2948372	Ren Klyce, Coya Elliott and David Parker	Ren Klyce, Coya Elliott, David Parker	nm0460274,nm0254208,nm0662188
-93	2020	Production	SOUND	SOUND	an1480729	Sound of Metal	tt5363618	Nicolas Becker, Jaime Baksht, Michellee Couttolenc, Carlos Cortés and Phillip Bladh	Nicolas Becker, Jaime Baksht, Michellee Couttolenc, Carlos Cortés, Phillip Bladh	nm0065545,nm0049254,nm2499159,nm3997636,nm3835694	True
+93	2020	Production	SOUND MIXING	SOUND	an1480732	Greyhound	tt6048922	Warren Shaw, Michael Minkler, Beau Borders and David Wyman	Warren Shaw, Michael Minkler, Beau Borders, David Wyman	nm0790022,nm0591444,nm0003311,nm1049027
+93	2020	Production	SOUND MIXING	SOUND	an1480731	Mank	tt10618286	Ren Klyce, Jeremy Molod, David Parker, Nathan Nance and Drew Kunin	Ren Klyce, Jeremy Molod, David Parker, Nathan Nance, Drew Kunin	nm0460274,nm0597199,nm0662188,nm2315737,nm0475168
+93	2020	Production	SOUND MIXING	SOUND	an1480733	News of the World	tt6878306	Oliver Tarney, Mike Prestwood Smith, William Miller and John Pritchett	Oliver Tarney, Mike Prestwood Smith, William Miller, John Pritchett	nm0850549,nm0696523,nm7017920,nm0698099
+93	2020	Production	SOUND MIXING	SOUND	an1482217	Soul	tt2948372	Ren Klyce, Coya Elliott and David Parker	Ren Klyce, Coya Elliott, David Parker	nm0460274,nm0254208,nm0662188
+93	2020	Production	SOUND MIXING	SOUND	an1480729	Sound of Metal	tt5363618	Nicolas Becker, Jaime Baksht, Michellee Couttolenc, Carlos Cortés and Phillip Bladh	Nicolas Becker, Jaime Baksht, Michellee Couttolenc, Carlos Cortés, Phillip Bladh	nm0065545,nm0049254,nm2499159,nm3997636,nm3835694	True
 93	2020	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1482219	Love and Monsters	tt2222042	Matt Sloan, Genevieve Camilleri, Matt Everitt and Brian Cox	Matt Sloan, Genevieve Camilleri, Matt Everitt, Brian Cox	nm0805992,nm3784934,nm3051832,nm0184939
 93	2020	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1480712	The Midnight Sky	tt10539608	Matthew Kasmir, Christopher Lawrence, Max Solomon and David Watkins	Matthew Kasmir, Christopher Lawrence, Max Solomon, David Watkins	nm0440683,nm1165856,nm1281289,nm0914247
 93	2020	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1480713	Mulan	tt4566758	Sean Faden, Anders Langlands, Seth Maury and Steve Ingram	Sean Faden, Anders Langlands, Seth Maury, Steve Ingram	nm0264915,nm1619365,nm0561295,nm0409032
@@ -11563,11 +11563,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 94	2021	Title	BEST PICTURE	BEST PICTURE	an1638358	Nightmare Alley	tt7740496	Guillermo del Toro, J. Miles Dale and Bradley Cooper, Producers	Guillermo del Toro, J. Miles Dale, Bradley Cooper	nm0868219,nm0197703,nm0177896
 94	2021	Title	BEST PICTURE	BEST PICTURE	an1638343	The Power of the Dog	tt10293406	Jane Campion, Tanya Seghatchian, Emile Sherman, Iain Canning and Roger Frappier, Producers	Jane Campion, Tanya Seghatchian, Emile Sherman, Iain Canning, Roger Frappier	nm0001005,nm0782036,nm0792431,nm2096617,nm0292024
 94	2021	Title	BEST PICTURE	BEST PICTURE	an1638340	West Side Story	tt3581652	Steven Spielberg and Kristie Macosko Krieger, Producers	Steven Spielberg, Kristie Macosko Krieger	nm0000229,nm1069736
-94	2021	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1636323	Dune	tt1160419	Production Design: Patrice Vermette; Set Decoration: Zsuzsanna Sipos	Patrice Vermette, Zsuzsanna Sipos	nm0894411,nm4722060	True
-94	2021	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1638460	Nightmare Alley	tt7740496	Production Design: Tamara Deverell; Set Decoration: Shane Vieau	Tamara Deverell, Shane Vieau	nm0222383,nm0896580
-94	2021	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1638457	The Power of the Dog	tt10293406	Production Design: Grant Major; Set Decoration: Amber Richards	Grant Major, Amber Richards	nm0538194,nm1400384
-94	2021	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1638459	The Tragedy of Macbeth	tt10095582	Production Design: Stefan Dechant; Set Decoration: Nancy Haigh	Stefan Dechant, Nancy Haigh	nm0213754,nm0354101
-94	2021	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1638463	West Side Story	tt3581652	Production Design: Adam Stockhausen; Set Decoration: Rena DeAngelo	Adam Stockhausen, Rena DeAngelo	nm1360914,nm0213076
+94	2021	Production	ART DIRECTION	PRODUCTION DESIGN	an1636323	Dune	tt1160419	Production Design: Patrice Vermette; Set Decoration: Zsuzsanna Sipos	Patrice Vermette, Zsuzsanna Sipos	nm0894411,nm4722060	True
+94	2021	Production	ART DIRECTION	PRODUCTION DESIGN	an1638460	Nightmare Alley	tt7740496	Production Design: Tamara Deverell; Set Decoration: Shane Vieau	Tamara Deverell, Shane Vieau	nm0222383,nm0896580
+94	2021	Production	ART DIRECTION	PRODUCTION DESIGN	an1638457	The Power of the Dog	tt10293406	Production Design: Grant Major; Set Decoration: Amber Richards	Grant Major, Amber Richards	nm0538194,nm1400384
+94	2021	Production	ART DIRECTION	PRODUCTION DESIGN	an1638459	The Tragedy of Macbeth	tt10095582	Production Design: Stefan Dechant; Set Decoration: Nancy Haigh	Stefan Dechant, Nancy Haigh	nm0213754,nm0354101
+94	2021	Production	ART DIRECTION	PRODUCTION DESIGN	an1638463	West Side Story	tt3581652	Production Design: Adam Stockhausen; Set Decoration: Rena DeAngelo	Adam Stockhausen, Rena DeAngelo	nm1360914,nm0213076
 94	2021	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1638444	Affairs of the Art	tt14293560	Joanna Quinn and Les Mills	Joanna Quinn, Les Mills	nm0703885,nm0995104
 94	2021	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1641029	Bestia	tt14825950	Hugo Covarrubias and Tevo Díaz	Hugo Covarrubias, Tevo Díaz	nm4587241,nm0246746
 94	2021	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1638446	Boxballet	tt14825972	Anton Dyakov	Anton Dyakov	nm6436434
@@ -11578,11 +11578,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 94	2021	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1638395	The Long Goodbye	tt11924384	Aneil Karia and Riz Ahmed	Aneil Karia, Riz Ahmed	nm4090848,nm1981893	True
 94	2021	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1636313	On My Mind	tt15289736	Martin Strange-Hansen and Kim Magnusson	Martin Strange-Hansen, Kim Magnusson	nm1015687,nm0536385
 94	2021	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1638394	Please Hold	tt11383280	K.D. Dávila and Levin Menekse	K.D. Dávila, Levin Menekse	nm4944814,nm11049074
-94	2021	Production	SOUND	SOUND	an1638489	Belfast	tt12789558	Denise Yarde, Simon Chase, James Mather and Niv Adiri	Denise Yarde, Simon Chase, James Mather, Niv Adiri	nm1383719,nm1121283,nm0558450,nm1866364
-94	2021	Production	SOUND	SOUND	an1636306	Dune	tt1160419	Mac Ruth, Mark Mangini, Theo Green, Doug Hemphill and Ron Bartlett	Mac Ruth, Mark Mangini, Theo Green, Doug Hemphill, Ron Bartlett	nm0002314,nm0005625,nm1640468,nm0376153,nm0058897	True
-94	2021	Production	SOUND	SOUND	an1638487	No Time to Die	tt2382320	Simon Hayes, Oliver Tarney, James Harrison, Paul Massey and Mark Taylor	Simon Hayes, Oliver Tarney, James Harrison, Paul Massey, Mark Taylor	nm1536532,nm0850549,nm0365639,nm0557338,nm0852837
-94	2021	Production	SOUND	SOUND	an1638490	The Power of the Dog	tt10293406	Richard Flynn, Robert Mackenzie and Tara Webb	Richard Flynn, Robert Mackenzie, Tara Webb	nm0283601,nm1464727,nm4155608
-94	2021	Production	SOUND	SOUND	an1638486	West Side Story	tt3581652	Tod A. Maitland, Gary Rydstrom, Brian Chumney, Andy Nelson and Shawn Murphy	Tod A. Maitland, Gary Rydstrom, Brian Chumney, Andy Nelson, Shawn Murphy	nm0537972,nm0003977,nm1014073,nm0625144,nm0004156
+94	2021	Production	SOUND MIXING	SOUND	an1638489	Belfast	tt12789558	Denise Yarde, Simon Chase, James Mather and Niv Adiri	Denise Yarde, Simon Chase, James Mather, Niv Adiri	nm1383719,nm1121283,nm0558450,nm1866364
+94	2021	Production	SOUND MIXING	SOUND	an1636306	Dune	tt1160419	Mac Ruth, Mark Mangini, Theo Green, Doug Hemphill and Ron Bartlett	Mac Ruth, Mark Mangini, Theo Green, Doug Hemphill, Ron Bartlett	nm0002314,nm0005625,nm1640468,nm0376153,nm0058897	True
+94	2021	Production	SOUND MIXING	SOUND	an1638487	No Time to Die	tt2382320	Simon Hayes, Oliver Tarney, James Harrison, Paul Massey and Mark Taylor	Simon Hayes, Oliver Tarney, James Harrison, Paul Massey, Mark Taylor	nm1536532,nm0850549,nm0365639,nm0557338,nm0852837
+94	2021	Production	SOUND MIXING	SOUND	an1638490	The Power of the Dog	tt10293406	Richard Flynn, Robert Mackenzie and Tara Webb	Richard Flynn, Robert Mackenzie, Tara Webb	nm0283601,nm1464727,nm4155608
+94	2021	Production	SOUND MIXING	SOUND	an1638486	West Side Story	tt3581652	Tod A. Maitland, Gary Rydstrom, Brian Chumney, Andy Nelson and Shawn Murphy	Tod A. Maitland, Gary Rydstrom, Brian Chumney, Andy Nelson, Shawn Murphy	nm0537972,nm0003977,nm1014073,nm0625144,nm0004156
 94	2021	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1636320	Dune	tt1160419	Paul Lambert, Tristan Myles, Brian Connor and Gerd Nefzer	Paul Lambert, Tristan Myles, Brian Connor, Gerd Nefzer	nm0995902,nm1629597,nm0175391,nm0275382	True
 94	2021	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1638483	Free Guy	tt6264654	Swen Gillberg, Bryan Grill, Nikos Kalaitzidis and Dan Sudick	Swen Gillberg, Bryan Grill, Nikos Kalaitzidis, Dan Sudick	nm1089828,nm0341985,nm0435479,nm0837203
 94	2021	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1638482	No Time to Die	tt2382320	Charlie Noble, Joel Green, Jonathan Fawkner and Chris Corbould	Charlie Noble, Joel Green, Jonathan Fawkner, Chris Corbould	nm0633563,nm2539473,nm1000834,nm0179269
@@ -11687,11 +11687,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 95	2022	Title	BEST PICTURE	BEST PICTURE	an1825715	Top Gun: Maverick	tt1745960	Tom Cruise, Christopher McQuarrie, David Ellison and Jerry Bruckheimer, Producers	Tom Cruise, Christopher McQuarrie, David Ellison, Jerry Bruckheimer	nm0000129,nm0003160,nm1911103,nm0000988
 95	2022	Title	BEST PICTURE	BEST PICTURE	an1825728	Triangle of Sadness	tt7322224	Erik Hemmendorff and Philippe Bober, Producers	Erik Hemmendorff, Philippe Bober	nm1615036,nm0090350
 95	2022	Title	BEST PICTURE	BEST PICTURE	an1825725	Women Talking	tt13669038	Dede Gardner, Jeremy Kleiner and Frances McDormand, Producers	Dede Gardner, Jeremy Kleiner, Frances McDormand	nm0306890,nm1250070,nm0000531
-95	2022	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1829492	All Quiet on the Western Front	tt1016150	Production Design: Christian M. Goldbeck; Set Decoration: Ernestine Hipper	Christian M. Goldbeck, Ernestine Hipper	nm1024392,nm0386157	True
-95	2022	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1829486	Avatar: The Way of Water	tt1630029	Production Design: Dylan Cole and Ben Procter; Set Decoration: Vanessa Cole	Dylan Cole, Ben Procter, Vanessa Cole	nm1304499,nm1929546,nm1521435
-95	2022	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1819939	Babylon	tt10640346	Production Design: Florencia Martin; Set Decoration: Anthony Carlino	Florencia Martin, Anthony Carlino	nm3151515,nm2518113
-95	2022	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1829488	Elvis	tt3704428	Production Design: Catherine Martin and Karen Murphy; Set Decoration: Bev Dunn	Catherine Martin, Karen Murphy, Bev Dunn	nm0552039,nm0614422,nm1427646
-95	2022	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an1829485	The Fabelmans	tt14208870	Production Design: Rick Carter; Set Decoration: Karen O'Hara	Rick Carter, Karen O'Hara	nm0141437,nm0641286
+95	2022	Production	ART DIRECTION	PRODUCTION DESIGN	an1829492	All Quiet on the Western Front	tt1016150	Production Design: Christian M. Goldbeck; Set Decoration: Ernestine Hipper	Christian M. Goldbeck, Ernestine Hipper	nm1024392,nm0386157	True
+95	2022	Production	ART DIRECTION	PRODUCTION DESIGN	an1829486	Avatar: The Way of Water	tt1630029	Production Design: Dylan Cole and Ben Procter; Set Decoration: Vanessa Cole	Dylan Cole, Ben Procter, Vanessa Cole	nm1304499,nm1929546,nm1521435
+95	2022	Production	ART DIRECTION	PRODUCTION DESIGN	an1819939	Babylon	tt10640346	Production Design: Florencia Martin; Set Decoration: Anthony Carlino	Florencia Martin, Anthony Carlino	nm3151515,nm2518113
+95	2022	Production	ART DIRECTION	PRODUCTION DESIGN	an1829488	Elvis	tt3704428	Production Design: Catherine Martin and Karen Murphy; Set Decoration: Bev Dunn	Catherine Martin, Karen Murphy, Bev Dunn	nm0552039,nm0614422,nm1427646
+95	2022	Production	ART DIRECTION	PRODUCTION DESIGN	an1829485	The Fabelmans	tt14208870	Production Design: Rick Carter; Set Decoration: Karen O'Hara	Rick Carter, Karen O'Hara	nm0141437,nm0641286
 95	2022	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1820097	The Boy, the Mole, the Fox and the Horse	tt22667880	Charlie Mackesy and Matthew Freud	Charlie Mackesy, Matthew Freud	nm12104786,nm2516361	True
 95	2022	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1820099	The Flying Sailor	tt20240228	Amanda Forbis and Wendy Tilby	Amanda Forbis, Wendy Tilby	nm0285428,nm0863195
 95	2022	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an1820101	Ice Merchants	tt19781688	João Gonzalez and Bruno Caetano	João Gonzalez, Bruno Caetano	nm11993514,nm4289854
@@ -11702,11 +11702,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 95	2022	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1820124	Le Pupille	tt20215392	Alice Rohrwacher and Alfonso Cuarón	Alice Rohrwacher, Alfonso Cuarón	nm3114621,nm0190859
 95	2022	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1834631	Night Ride	tt12566792	Eirik Tveiten and Gaute Lid Larssen	Eirik Tveiten, Gaute Lid Larssen	nm5012126,nm0489118
 95	2022	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an1820129	The Red Suitcase	tt22763378	Cyrus Neshvad	Cyrus Neshvad	nm1293977
-95	2022	Production	SOUND	SOUND	an1820136	All Quiet on the Western Front	tt1016150	Viktor Prášil, Frank Kruse, Markus Stemler, Lars Ginzel and Stefan Korte	Viktor Prášil, Frank Kruse, Markus Stemler, Lars Ginzel, Stefan Korte	nm3920810,nm0006838,nm2028874,nm1038597,nm0466745
-95	2022	Production	SOUND	SOUND	an1820137	Avatar: The Way of Water	tt1630029	Julian Howarth, Gwendolyn Yates Whittle, Dick Bernstein, Christopher Boyes, Gary Summers and Michael Hedges	Julian Howarth, Gwendolyn Yates Whittle, Dick Bernstein, Christopher Boyes, Gary Summers, Michael Hedges	nm0397719,nm0946705,nm0077031,nm0102110,nm0838707,nm0373276
-95	2022	Production	SOUND	SOUND	an1820139	The Batman	tt1877830	Stuart Wilson, William Files, Douglas Murray and Andy Nelson	Stuart Wilson, William Files, Douglas Murray, Andy Nelson	nm0934184,nm0276877,nm0614923,nm0625144
-95	2022	Production	SOUND	SOUND	an1820141	Elvis	tt3704428	David Lee, Wayne Pashley, Andy Nelson and Michael Keller	David Lee, Wayne Pashley, Andy Nelson, Michael Keller	nm1325883,nm0664563,nm0625144,nm0445728
-95	2022	Production	SOUND	SOUND	an1820145	Top Gun: Maverick	tt1745960	Mark Weingarten, James H. Mather, Al Nelson, Chris Burdon and Mark Taylor	Mark Weingarten, James H. Mather, Al Nelson, Chris Burdon, Mark Taylor	nm0918319,nm0558450,nm0625131,nm0121006,nm0852837	True
+95	2022	Production	SOUND MIXING	SOUND	an1820136	All Quiet on the Western Front	tt1016150	Viktor Prášil, Frank Kruse, Markus Stemler, Lars Ginzel and Stefan Korte	Viktor Prášil, Frank Kruse, Markus Stemler, Lars Ginzel, Stefan Korte	nm3920810,nm0006838,nm2028874,nm1038597,nm0466745
+95	2022	Production	SOUND MIXING	SOUND	an1820137	Avatar: The Way of Water	tt1630029	Julian Howarth, Gwendolyn Yates Whittle, Dick Bernstein, Christopher Boyes, Gary Summers and Michael Hedges	Julian Howarth, Gwendolyn Yates Whittle, Dick Bernstein, Christopher Boyes, Gary Summers, Michael Hedges	nm0397719,nm0946705,nm0077031,nm0102110,nm0838707,nm0373276
+95	2022	Production	SOUND MIXING	SOUND	an1820139	The Batman	tt1877830	Stuart Wilson, William Files, Douglas Murray and Andy Nelson	Stuart Wilson, William Files, Douglas Murray, Andy Nelson	nm0934184,nm0276877,nm0614923,nm0625144
+95	2022	Production	SOUND MIXING	SOUND	an1820141	Elvis	tt3704428	David Lee, Wayne Pashley, Andy Nelson and Michael Keller	David Lee, Wayne Pashley, Andy Nelson, Michael Keller	nm1325883,nm0664563,nm0625144,nm0445728
+95	2022	Production	SOUND MIXING	SOUND	an1820145	Top Gun: Maverick	tt1745960	Mark Weingarten, James H. Mather, Al Nelson, Chris Burdon and Mark Taylor	Mark Weingarten, James H. Mather, Al Nelson, Chris Burdon, Mark Taylor	nm0918319,nm0558450,nm0625131,nm0121006,nm0852837	True
 95	2022	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1820146	All Quiet on the Western Front	tt1016150	Frank Petzold, Viktor Müller, Markus Frank and Kamil Jafar	Frank Petzold, Viktor Müller, Markus Frank, Kamil Jafar	nm0004182,nm0612260,nm5856743,nm1141645
 95	2022	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1820147	Avatar: The Way of Water	tt1630029	Joe Letteri, Richard Baneham, Eric Saindon and Daniel Barrett	Joe Letteri, Richard Baneham, Eric Saindon, Daniel Barrett	nm0504784,nm0051824,nm0756590,nm2280778	True
 95	2022	Production	VISUAL EFFECTS	VISUAL EFFECTS	an1820148	The Batman	tt1877830	Dan Lemmon, Russell Earl, Anders Langlands and Dominic Tuohy	Dan Lemmon, Russell Earl, Anders Langlands, Dominic Tuohy	nm0501424,nm0247270,nm1619365,nm0876716
@@ -11820,11 +11820,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 96	2023	Title	BEST PICTURE	BEST PICTURE	an2043468	Past Lives	tt13238346	David Hinojosa, Christine Vachon and Pamela Koffler, Producers	David Hinojosa, Christine Vachon, Pamela Koffler	nm3065267,nm0882927,nm0463025
 96	2023	Title	BEST PICTURE	BEST PICTURE	an2043464	Poor Things	tt14230458	Ed Guiney, Andrew Lowe, Yorgos Lanthimos and Emma Stone, Producers	Ed Guiney, Andrew Lowe, Yorgos Lanthimos, Emma Stone	nm0347384,nm1103466,nm0487166,nm1297015
 96	2023	Title	BEST PICTURE	BEST PICTURE	an2043470	The Zone of Interest	tt7160372	James Wilson, Producer	James Wilson	nm1034914
-96	2023	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an2043610	Barbie	tt1517268	Production Design: Sarah Greenwood; Set Decoration: Katie Spencer	Sarah Greenwood, Katie Spencer	nm0339391,nm0818005
-96	2023	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an2043613	Killers of the Flower Moon	tt5537002	Production Design: Jack Fisk; Set Decoration: Adam Willis	Jack Fisk, Adam Willis	nm0279926,nm1853964
-96	2023	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an2043618	Napoleon	tt13287846	Production Design: Arthur Max; Set Decoration: Elli Griff	Arthur Max, Elli Griff	nm0561480,nm0341066
-96	2023	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an2043611	Oppenheimer	tt15398776	Production Design: Ruth De Jong; Set Decoration: Claire Kaufman	Ruth De Jong, Claire Kaufman	nm1968338,nm0442114
-96	2023	Production	PRODUCTION DESIGN	PRODUCTION DESIGN	an2043612	Poor Things	tt14230458	Production Design: James Price and Shona Heath; Set Decoration: Zsuzsa Mihalek	James Price, Shona Heath, Zsuzsa Mihalek	nm1483016,nm4257419,nm1386368	True
+96	2023	Production	ART DIRECTION	PRODUCTION DESIGN	an2043610	Barbie	tt1517268	Production Design: Sarah Greenwood; Set Decoration: Katie Spencer	Sarah Greenwood, Katie Spencer	nm0339391,nm0818005
+96	2023	Production	ART DIRECTION	PRODUCTION DESIGN	an2043613	Killers of the Flower Moon	tt5537002	Production Design: Jack Fisk; Set Decoration: Adam Willis	Jack Fisk, Adam Willis	nm0279926,nm1853964
+96	2023	Production	ART DIRECTION	PRODUCTION DESIGN	an2043618	Napoleon	tt13287846	Production Design: Arthur Max; Set Decoration: Elli Griff	Arthur Max, Elli Griff	nm0561480,nm0341066
+96	2023	Production	ART DIRECTION	PRODUCTION DESIGN	an2043611	Oppenheimer	tt15398776	Production Design: Ruth De Jong; Set Decoration: Claire Kaufman	Ruth De Jong, Claire Kaufman	nm1968338,nm0442114
+96	2023	Production	ART DIRECTION	PRODUCTION DESIGN	an2043612	Poor Things	tt14230458	Production Design: James Price and Shona Heath; Set Decoration: Zsuzsa Mihalek	James Price, Shona Heath, Zsuzsa Mihalek	nm1483016,nm4257419,nm1386368	True
 96	2023	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an2026608	Letter to a Pig	tt10346066	Tal Kantor and Amit R. Gicelter	Tal Kantor, Amit R. Gicelter	nm7722734,nm1206834
 96	2023	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an2026609	Ninety-Five Senses	tt11020596	Jerusha Hess and Jared Hess	Jerusha Hess, Jared Hess	nm1415801,nm0381478
 96	2023	Title	SHORT FILM (Animated)	SHORT FILM (Animated)	an2026611	Our Uniform	tt28058015	Yegane Moghaddam	Yegane Moghaddam	nm10057416
@@ -11835,11 +11835,11 @@ Ceremony	Year	Class	CanonicalCategory	Category	NomId	Film	FilmId	Name	Nominees	N
 96	2023	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an2026629	Knight of Fortune	tt26600054	Lasse Lyskjær Noer and Christian Norlyk	Lasse Lyskjær Noer, Christian Norlyk	nm10210418,nm10210414
 96	2023	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an2026631	Red, White and Blue	tt27759823	Nazrin Choudhury and Sara McFarlane	Nazrin Choudhury, Sara McFarlane	nm1135653,nm10626793
 96	2023	Title	SHORT FILM (Live Action)	SHORT FILM (Live Action)	an2026644	The Wonderful Story of Henry Sugar	tt16968450	Wes Anderson and Steven Rales	Wes Anderson, Steven Rales	nm0027572,nm2262509	True
-96	2023	Production	SOUND	SOUND	an2026648	The Creator	tt11858890	Ian Voigt, Erik Aadahl, Ethan Van der Ryn, Tom Ozanich and Dean Zupancic	Ian Voigt, Erik Aadahl, Ethan Van der Ryn, Tom Ozanich, Dean Zupancic	nm0901189,nm0007321,nm0886399,nm0654696,nm0958711
-96	2023	Production	SOUND	SOUND	an2026652	Maestro	tt5535276	Steven A. Morrow, Richard King, Jason Ruder, Tom Ozanich and Dean Zupancic	Steven A. Morrow, Richard King, Jason Ruder, Tom Ozanich, Dean Zupancic	nm0607551,nm0455185,nm1720819,nm0654696,nm0958711
-96	2023	Production	SOUND	SOUND	an2026653	Mission: Impossible - Dead Reckoning Part One	tt9603212	Chris Munro, James H. Mather, Chris Burdon and Mark Taylor	Chris Munro, James H. Mather, Chris Burdon, Mark Taylor	nm0613101,nm0558450,nm0121006,nm0852837
-96	2023	Production	SOUND	SOUND	an2026656	Oppenheimer	tt15398776	Willie Burton, Richard King, Gary A. Rizzo and Kevin O'Connell	Willie Burton, Richard King, Gary A. Rizzo, Kevin O'Connell	nm0123770,nm0455185,nm0729886,nm0640114
-96	2023	Production	SOUND	SOUND	an2026657	The Zone of Interest	tt7160372	Tarn Willers and Johnnie Burn	Tarn Willers, Johnnie Burn	nm1353680,nm1908855	True
+96	2023	Production	SOUND MIXING	SOUND	an2026648	The Creator	tt11858890	Ian Voigt, Erik Aadahl, Ethan Van der Ryn, Tom Ozanich and Dean Zupancic	Ian Voigt, Erik Aadahl, Ethan Van der Ryn, Tom Ozanich, Dean Zupancic	nm0901189,nm0007321,nm0886399,nm0654696,nm0958711
+96	2023	Production	SOUND MIXING	SOUND	an2026652	Maestro	tt5535276	Steven A. Morrow, Richard King, Jason Ruder, Tom Ozanich and Dean Zupancic	Steven A. Morrow, Richard King, Jason Ruder, Tom Ozanich, Dean Zupancic	nm0607551,nm0455185,nm1720819,nm0654696,nm0958711
+96	2023	Production	SOUND MIXING	SOUND	an2026653	Mission: Impossible - Dead Reckoning Part One	tt9603212	Chris Munro, James H. Mather, Chris Burdon and Mark Taylor	Chris Munro, James H. Mather, Chris Burdon, Mark Taylor	nm0613101,nm0558450,nm0121006,nm0852837
+96	2023	Production	SOUND MIXING	SOUND	an2026656	Oppenheimer	tt15398776	Willie Burton, Richard King, Gary A. Rizzo and Kevin O'Connell	Willie Burton, Richard King, Gary A. Rizzo, Kevin O'Connell	nm0123770,nm0455185,nm0729886,nm0640114
+96	2023	Production	SOUND MIXING	SOUND	an2026657	The Zone of Interest	tt7160372	Tarn Willers and Johnnie Burn	Tarn Willers, Johnnie Burn	nm1353680,nm1908855	True
 96	2023	Production	VISUAL EFFECTS	VISUAL EFFECTS	an2026658	The Creator	tt11858890	Jay Cooper, Ian Comley, Andrew Roberts and Neil Corbould	Jay Cooper, Ian Comley, Andrew Roberts, Neil Corbould	nm0178134,nm2026173,nm1209102,nm0179273
 96	2023	Production	VISUAL EFFECTS	VISUAL EFFECTS	an2026660	Godzilla Minus One	tt23289160	Takashi Yamazaki, Kiyoko Shibuya, Masaki Takahashi and Tatsuji Nojima	Takashi Yamazaki, Kiyoko Shibuya, Masaki Takahashi, Tatsuji Nojima	nm0945724,nm2181714,nm15597114,nm10213275	True
 96	2023	Production	VISUAL EFFECTS	VISUAL EFFECTS	an2026661	Guardians of the Galaxy Vol. 3	tt6791350	Stephane Ceretti, Alexis Wajsbrot, Guy Williams and Theo Bialek	Stephane Ceretti, Alexis Wajsbrot, Guy Williams, Theo Bialek	nm0148547,nm2528062,nm1401413,nm1322273


### PR DESCRIPTION
The category names that I'm merging, and why I believe they're basically the same. 

## Actor/Actress [in a leading role]
`ACTRESS` was given out Ceremonies 1-48. In 49, they started giving out `ACTRESS IN A LEADING ROLE`. Ditto `ACTOR`. 

## Short Film ([Dramatic] Live Action)
`SHORT FILM (Live Action)` was given out every ceremony from 47 on, except for 53. That was the only year when the title was `SHORT FILM (Dramatic Live Action)`

## Sound [Mixing]
`SOUND` was given out ceremonies 31-75 and 93-96. `SOUND MIXING` was 76-92. 

## Art Direction / Production Design
`ART DIRECTION` was awarded in 1-12, at which point they split it into two categories, for Color and Black/White for 13-39. Then for 30 and 31, it was back to `ART DIRECTION`, then back to split for 32-39, then back to `ART DIRECTION` for 40-84. Then from 85 on, it was `PRODUCTION DESIGN` but I'm calling it `ART DIRECTION` because that was used for longer, and more clearly differentiates between that and the split versions. 

## Writing [Adapted] [Screenplay]
In Ceremony 1, there were writing categories for `WRITING (Original Story)` and `WRITING (Adaptation)`. Some version of the Story category continued ceremonies 4-29. However, in Ceremony 13, Original Screenplay started being a category, so that leads to at least three distinct categories. Ceremony 29 is where it Story was eliminated and the Original/Adapted division was clearly divided. 

Prior to that, it was just `WRITING` in 2 and 3, `WRITING (Adaptation)` in 4-7, and then `WRITING (Screenplay)` 8-28. I've lumped these categories into the larger `Adapted Screenplay` category because they do not overlap with any other equivalents, whereas they do overlap with `Original Screenplay` equivalents. 

## Music Scoring
Its complicated, just trust me. 

